### PR TITLE
Removed duplicate vcsrepo entry in puppet

### DIFF
--- a/vagrant/puppet/manifests/init.pp
+++ b/vagrant/puppet/manifests/init.pp
@@ -35,14 +35,6 @@ package { ['python-software-properties', 'vim', 'git', 'dsh']:
 
 include nginx, php #, mysql
 
-vcsrepo { "/var/www/":
-  ensure => latest,
-  provider => git,
-  require => [ Package[ 'git' ] ],
-  source => "https://someuser:password@github.com/Aloja/aloja.git",
-  revision => 'azureProd',
-}
-
 #include '::mysql::server'
 if $environment == 'prod' {
    $mysql_options = {'bind-address' => '0.0.0.0',


### PR DESCRIPTION
I think it was duplicated by mistake, because it's defined again inside a `if $environment == 'prod'` a little bit after. This caused errors when provisioning the vagrant machine.
