### PR TITLE
Fixed Hive query execution through Aloja

### DIFF
--- a/shell/common/common_hive.sh
+++ b/shell/common/common_hive.sh
@@ -100,17 +100,15 @@ execute_hive(){
 
 initialize_hive_vars() {
 
-  BENCH_CONFIG_FOLDERS="$BENCH_CONFIG_FOLDERS hive_conf_template"
-
   if [ "$clusterType" == "PaaS" ]; then
     HIVE_HOME="/usr"
     HIVE_CONF_DIR="/etc/hive/conf"
-    [ ! "$HIVE_SETTINGS_FILE" ] && HIVE_SETTINGS_FILE="$HDD/hive_conf/hive.settings_PaaS"
+    [ ! "$HIVE_SETTINGS_FILE" ] && HIVE_SETTINGS_FILE="$(get_local_bench_path)/hive_conf/hive.settings_PaaS"
   else
     HIVE_HOME="$(get_local_apps_path)/apache-hive-${HIVE_VERSION}-bin"
-    HIVE_CONF_DIR="$HDD/hive_conf"
+    HIVE_CONF_DIR="$(get_local_bench_path)/hive_conf"
 
-    [ ! "$HIVE_SETTINGS_FILE" ] && HIVE_SETTINGS_FILE="$HDD/hive_conf/hive.settings"
+    [ ! "$HIVE_SETTINGS_FILE" ] && HIVE_SETTINGS_FILE="$(get_local_bench_path)/hive_conf/hive.settings"
 
     if [ "$HIVE_ENGINE" == "tez" ]; then
       initialize_tez_vars
@@ -176,7 +174,7 @@ s,##JAVA_XMS##,$JAVA_XMS,g;
 s,##JAVA_XMX##,$JAVA_XMX,g;
 s,##JAVA_AM_XMS##,$JAVA_AM_XMS,g;
 s,##JAVA_AM_XMX##,$JAVA_AM_XMX,g;
-s,##LOG_DIR##,$HDD/hive_logs,g;
+s,##LOG_DIR##,$(get_local_bench_path)/hive_logs,g;
 s,##REPLICATION##,$REPLICATION,g;
 s,##MASTER##,$master_name,g;
 s,##NAMENODE##,$master_name,g;
@@ -203,7 +201,7 @@ s,##MAPS_MB##,$MAPS_MB,g;
 s,##REDUCES_MB##,$REDUCES_MB,g;
 s,##AM_MB##,$AM_MB,g;
 s,##BENCH_LOCAL_DIR##,$BENCH_LOCAL_DIR,g;
-s,##HDD##,$HDD,g;
+s,##HDD##,$(get_local_bench_path),g;
 s,##HIVE_ENGINE##,$HIVE_ENGINE,g;
 s,##HIVE_JOINS##,$HIVE_JOINS,g;
 s,##DATABASE_DRIVER##,$database_driver,g;
@@ -213,7 +211,7 @@ EOF
 }
 
 get_hive_conf_dir() {
-  echo -e "$HDD/hive_conf"
+  echo -e "$(get_local_bench_path)/hive_conf"
 }
 
 prepare_hive_config() {
@@ -233,7 +231,7 @@ prepare_hive_config() {
 
   else
     logger "INFO: Preparing Hive run specific config"
-    $DSH "mkdir -p $(get_hive_conf_dir) $HDD/hive_logs; cp -r $(get_local_configs_path)/hive$(get_hive_major_version)_conf_template/* $(get_hive_conf_dir);"
+    $DSH "mkdir -p $(get_hive_conf_dir) $(get_local_bench_path)/hive_logs; cp -r $(get_local_configs_path)/hive$(get_hive_major_version)_conf_template/* $(get_hive_conf_dir);"
 
     # Get the values
     subs=$(get_hive_substitutions)
@@ -300,13 +298,13 @@ save_hive() {
     $DSH_MASTER "cd /etc/hive; tar -cjf $JOB_PATH/hive_conf.tar.bz2 conf"
   else
     if [ "$BENCH_LEAVE_SERVICES" ] ; then
-      $DSH "cp $HDD/hive_logs/* $JOB_PATH/$bench_name_num/hive_logs/ 2> /dev/null"
+      $DSH "cp $(get_local_bench_path)/hive_logs/* $JOB_PATH/$bench_name_num/hive_logs/ 2> /dev/null"
     else
-      $DSH "mv $HDD/hive_logs/* $JOB_PATH/$bench_name_num/hive_logs/ 2> /dev/null"
+      $DSH "mv $(get_local_bench_path)/hive_logs/* $JOB_PATH/$bench_name_num/hive_logs/ 2> /dev/null"
     fi
 
     # Save Hive conf
-    $DSH_MASTER "cd $HDD/; tar -cjf $JOB_PATH/hive_conf.tar.bz2 hive_conf"
+    $DSH_MASTER "cd $(get_local_bench_path)/; tar -cjf $JOB_PATH/hive_conf.tar.bz2 hive_conf"
   fi
 
   logger "INFO: Compresing and deleting hadoop configs for $bench_name_num"


### PR DESCRIPTION
A small hotfix that allows to run Hive queries through aloja once again using execute_hive()