### PR TITLE
Remove Minerva-111 from cluster definition

### DIFF
--- a/shell/conf/cluster_minerva100-02-18-22.conf
+++ b/shell/conf/cluster_minerva100-02-18-22.conf
@@ -6,9 +6,9 @@ defaultProvider="minerva100"
 
 clusterID="$(get_id_cluster "$(basename $BASH_SOURCE)")"
 clusterName="minerva100-02-18-$clusterID"
-numberOfNodes="16" #starts at 0 (max 99)
+numberOfNodes="15" #starts at 0 (max 99)
 
-nodeNames="$(seq -f 'minerva-%0g' 102 118)"
+nodeNames="$(printf 'minerva-%d\n' {102..110} {112..118})"
 
 useProxy="ssh -i ../secure/keys/id_rsa npoggi@minerva.bsc.es -p 22 nc %h %p 2> /dev/null"
 


### PR DESCRIPTION
Minerva-111 suffered from a hard drive malfunction that makes the node
impossible to use. This fix makes it possible to use the whole available
minerva nodes for computation, other smaller sub-clusters definitions
need to be fixed as well.