### PR TITLE
Refactor Aloja bench size management

### DIFF
--- a/shell/common/benchmark_D2F-native-spark.sh
+++ b/shell/common/benchmark_D2F-native-spark.sh
@@ -40,12 +40,6 @@ BENCH_REQUIRED_FILES["$NATIVE_SPARK_FOLDER_NAME"]="https://github.com/rradowitz/
 # Local
 NATIVE_SPARK_LOCAL_DIR="$(get_local_apps_path)/$NATIVE_SPARK_FOLDER_NAME"
 
-# Set scaleFactor for data input dir
-SCALE_FACTOR="$TPCH_SCALE_FACTOR"
-if [[ "$TPCH_USE_LOCAL_FACTOR" -gt 0 ]] ; then
-  SCALE_FACTOR="$TPCH_USE_LOCAL_FACTOR"
-fi
-
 if [[ "$NATIVE_FORMAT" == "text" ]]; then
   NATIVE_INPUT_DIR="/tmp/tpch-generate/$SCALE_FACTOR"
   logger "INFO: Setting INPUT_DIR to $NATIVE_INPUT_DIR"

--- a/shell/common/common_TPC-H.sh
+++ b/shell/common/common_TPC-H.sh
@@ -14,19 +14,16 @@ if [[ "$BB_SERVER_DERBY" == "true" ]]; then
   set_derby_requires
 fi
 
-if [[ "$TPCH_USE_LOCAL_FACTOR" -gt 0 ]]; then
-  TPCH_SCALE_FACTOR=$TPCH_USE_LOCAL_FACTOR
-  BENCH_DATA_SIZE="$((TPCH_USE_LOCAL_FACTOR * 1000000000 ))" #in bytes
-else
-  [[ ! "$TPCH_SCALE_FACTOR" ]] && TPCH_SCALE_FACTOR=1 #1 GB min size
-  BENCH_DATA_SIZE="$((TPCH_SCALE_FACTOR * 1000000000 ))" #in bytes
+if [ "$(get_benchmark_data_size_gb)" -lt 1 ] ; then #Should only happen when BENCH_DATA_SIZE < 1GB
+  logger "WARNING: TPC-H data size is set below minimum value, setting data size to 1GB"
+  BENCH_DATA_SIZE=1000000000
 fi
 
 TPCH_HDFS_DIR="/tmp/tpch-generate"
 
 if [[ ! "$NATIVE_FORMAT" == "text"  || ! "$BENCH_SUITE" == *"native-spark"* ]]; then
   [[ ! -z $NATIVE_FORMAT ]] && BENCH_FILE_FORMAT=$NATIVE_FORMAT
-  TPCH_DB_NAME="tpch_${BENCH_FILE_FORMAT}_${TPCH_SCALE_FACTOR}"
+  TPCH_DB_NAME="tpch_${BENCH_FILE_FORMAT}_$(get_benchmark_data_size_gb)"
 fi
 
 [[ ! "$BENCH_LIST" ]] && BENCH_LIST="$(printf '%d ' {1..22})"
@@ -101,46 +98,48 @@ tpc-h_build(){
 tpc-h_hadoop_datagen() {
   local bench_name="${FUNCNAME[0]}"
   logger "Running TPC-H data generator M/R job"
-  hadoop_delete_path "$bench_name" "$TPCH_HDFS_DIR/$TPCH_SCALE_FACTOR"
-  execute_hadoop_new "$bench_name" "jar target/*.jar $(get_hadoop_job_config) -d $TPCH_HDFS_DIR/$TPCH_SCALE_FACTOR/ -s $TPCH_SCALE_FACTOR" "time" "$D2F_local_dir/tpch/tpch-gen"
+  hadoop_delete_path "$bench_name" "$TPCH_HDFS_DIR/$(get_benchmark_data_size_gb)"
+  execute_hadoop_new "$bench_name" "jar target/*.jar $(get_hadoop_job_config) -d $TPCH_HDFS_DIR/$(get_benchmark_data_size_gb)/ -s $(get_benchmark_data_size_gb)" "time" "$D2F_local_dir/tpch/tpch-gen"
 }
 
 # Generate the data using the command line version (non-distributed)
 # $1 scale factor
 tpc-h_cmd_datagen() {
   local scale_factor="$1"
+  local src_dir="$D2F_local_dir/tpch/tpch-gen/target/tools/"
+  local dst_dir="$TPCH_HDFS_DIR/$(get_benchmark_data_size_gb)"
   local bench_name="${FUNCNAME[0]}"
   logger "Running TPC-H cmd line data generator for scale $scale_factor"
 
   # Generate the data
-  time_cmd_master "cd $D2F_local_dir/tpch/tpch-gen/target/tools; $D2F_local_dir/tpch/tpch-gen/target/tools/dbgen -b $D2F_local_dir/tpch/tpch-gen/target/tools/dists.dss -vf -s $scale_factor; "
+  time_cmd_master "cd \"$D2F_local_dir/tpch/tpch-gen/target/tools\" ; \"$D2F_local_dir/tpch/tpch-gen/target/tools/dbgen\" -b \"$D2F_local_dir/tpch/tpch-gen/target/tools/dists.dss\" -vf -s \"$scale_factor\""
 
   # Move the files to HDFS
-  hadoop_delete_path "$bench_name" "$TPCH_HDFS_DIR/$TPCH_SCALE_FACTOR"
-  execute_hadoop_new "$bench_name" "fs -mkdir -p $TPCH_HDFS_DIR/$TPCH_SCALE_FACTOR/{customer,lineitem,nation,orders,part,partsupp,region,supplier}"
+  hadoop_delete_path "$bench_name" "\"$TPCH_HDFS_DIR/$(get_benchmark_data_size_gb)\""
+  execute_hadoop_new "$bench_name" "fs -mkdir -p \"$TPCH_HDFS_DIR/$(get_benchmark_data_size_gb)\"/{customer,lineitem,nation,orders,part,partsupp,region,supplier}"
 
-  execute_hadoop_new "$bench_name" "fs -moveFromLocal $D2F_local_dir/tpch/tpch-gen/target/tools/customer.tbl $TPCH_HDFS_DIR/$TPCH_SCALE_FACTOR/customer/"
-  execute_hadoop_new "$bench_name" "fs -moveFromLocal $D2F_local_dir/tpch/tpch-gen/target/tools/lineitem.tbl $TPCH_HDFS_DIR/$TPCH_SCALE_FACTOR/lineitem/"
-  execute_hadoop_new "$bench_name" "fs -moveFromLocal $D2F_local_dir/tpch/tpch-gen/target/tools/nation.tbl $TPCH_HDFS_DIR/$TPCH_SCALE_FACTOR/nation/"
-  execute_hadoop_new "$bench_name" "fs -moveFromLocal $D2F_local_dir/tpch/tpch-gen/target/tools/orders.tbl $TPCH_HDFS_DIR/$TPCH_SCALE_FACTOR/orders/"
-  execute_hadoop_new "$bench_name" "fs -moveFromLocal $D2F_local_dir/tpch/tpch-gen/target/tools/part.tbl $TPCH_HDFS_DIR/$TPCH_SCALE_FACTOR/part/"
-  execute_hadoop_new "$bench_name" "fs -moveFromLocal $D2F_local_dir/tpch/tpch-gen/target/tools/partsupp.tbl $TPCH_HDFS_DIR/$TPCH_SCALE_FACTOR/partsupp/"
-  execute_hadoop_new "$bench_name" "fs -moveFromLocal $D2F_local_dir/tpch/tpch-gen/target/tools/region.tbl $TPCH_HDFS_DIR/$TPCH_SCALE_FACTOR/region/"
-  execute_hadoop_new "$bench_name" "fs -moveFromLocal $D2F_local_dir/tpch/tpch-gen/target/tools/supplier.tbl $TPCH_HDFS_DIR/$TPCH_SCALE_FACTOR/supplier/"
+  execute_hadoop_new "$bench_name" "fs -moveFromLocal \"$src_dir/customer.tbl\" \"$dst_dir/customer/\""
+  execute_hadoop_new "$bench_name" "fs -moveFromLocal \"$src_dir/lineitem.tbl\" \"$dst_dir/lineitem/\""
+  execute_hadoop_new "$bench_name" "fs -moveFromLocal \"$src_dir/nation.tbl\" \"$dst_dir/nation/\""
+  execute_hadoop_new "$bench_name" "fs -moveFromLocal \"$src_dir/orders.tbl\" \"$dst_dir/orders/\""
+  execute_hadoop_new "$bench_name" "fs -moveFromLocal \"$src_dir/part.tbl\" \"$dst_dir/part/\""
+  execute_hadoop_new "$bench_name" "fs -moveFromLocal \"$src_dir/partsupp.tbl\" \"$dst_dir/partsupp/\""
+  execute_hadoop_new "$bench_name" "fs -moveFromLocal \"$src_dir/region.tbl\" \"$dst_dir/region/\""
+  execute_hadoop_new "$bench_name" "fs -moveFromLocal \"$src_dir/supplier.tbl\" \"$dst_dir/supplier/\""
 }
 
 tpc-h_load-text(){
   local bench_name="${FUNCNAME[0]}"
 
   logger "INFO: Loading text data into external tables"
-  execute_hive "$bench_name" "-f $D2F_local_dir/tpch/ddl/alltables.sql -d DB=tpch_text_$TPCH_SCALE_FACTOR -d LOCATION=$TPCH_HDFS_DIR/$TPCH_SCALE_FACTOR" "time"
+  execute_hive "$bench_name" "-f $D2F_local_dir/tpch/ddl/alltables.sql -d DB=tpch_text_$(get_benchmark_data_size_gb) -d LOCATION=$TPCH_HDFS_DIR/$(get_benchmark_data_size_gb)" "time"
 }
 
 tpc-h_delete-text(){
   local bench_name="${FUNCNAME[0]}"
 
   logger "INFO: Deleting external plain tables to save space (if BENCH_KEEP_FILES is not set)"
-  clean_HDFS "$bench_name" "$TPCH_HDFS_DIR/$TPCH_SCALE_FACTOR"
+  clean_HDFS "$bench_name" "$TPCH_HDFS_DIR/$(get_benchmark_data_size_gb)"
 }
 
 tpc-h_load-optimize() {
@@ -163,7 +162,7 @@ tpc-h_load-optimize() {
 
   local optimize_cmd="-f $all_path \
   -d DB=$TPCH_DB_NAME \
-  -d SOURCE=tpch_text_$TPCH_SCALE_FACTOR -d BUCKETS=$BUCKETS \
+  -d SOURCE=tpch_text_$(get_benchmark_data_size_gb) -d BUCKETS=$BUCKETS \
   -d FILE=$BENCH_FILE_FORMAT"
 
   logger "INFO: Optimizing tables: $TABLES using $BUCKETS buckets."
@@ -177,7 +176,7 @@ tpc-h_validate_load() {
   local bench_name="${FUNCNAME[0]}"
 
   logger "INFO: attempting to validate load and optimize to DB: $TPCH_DB_NAME"
-  local db_stats="$(execute_hadoop_new "$bench_name" "fs -du /apps/hive/warehouse/tpch_orc_${TPCH_SCALE_FACTOR}.db" 2>1)"
+  local db_stats="$(execute_hadoop_new "$bench_name" "fs -du /apps/hive/warehouse/tpch_orc_$(get_benchmark_data_size_gb).db" 2>1)"
 
   logger "INFO: DB stats = $db_stats";
   logger "INFO: num tables = $(echo -e "$db_stats" |wc -l)";
@@ -186,7 +185,7 @@ tpc-h_validate_load() {
 tpc-h_delete_dbgen(){
   if [[ ! "$BENCH_KEEP_FILES" == "1" ]] && [[ ! "$BENCH_LEAVE_SERVICES" == "1" ]] ; then
     logger "INFO: deleting original DBGEN files to save space"
-    hadoop_delete_path "$bench_name" "$TPCH_HDFS_DIR/$TPCH_SCALE_FACTOR"
+    hadoop_delete_path "$bench_name" "$TPCH_HDFS_DIR/$(get_benchmark_data_size_gb)"
   fi
 }
 
@@ -196,9 +195,7 @@ if [[ ! "$BENCH_KEEP_FILES" ]] ; then
     tpc-h_build
 
     # Generate the data
-    if [[ "$TPCH_USE_LOCAL_FACTOR" -gt 0 ]] ; then
-      tpc-h_cmd_datagen "$TPCH_USE_LOCAL_FACTOR"
-    elif [[ "$TPCH_SCALE_FACTOR" == "1" ]] ; then
+    if [[ "$(get_benchmark_data_size_gb)" -eq "1" ]] ; then
       tpc-h_cmd_datagen "1"
     else
       tpc-h_hadoop_datagen
@@ -216,9 +213,7 @@ tpc-h_datagen() {
     tpc-h_build
 
     # Generate the data
-    if [[ "$TPCH_USE_LOCAL_FACTOR" -gt 0 ]] ; then
-      tpc-h_cmd_datagen "$TPCH_USE_LOCAL_FACTOR"
-    elif [[ "$TPCH_SCALE_FACTOR" == "1" ]] ; then
+    if [[ "$(get_benchmark_data_size_gb)" -eq "1" ]] ; then
       tpc-h_cmd_datagen "1"
     else
       tpc-h_hadoop_datagen

--- a/shell/conf/benchmarks_defaults.conf
+++ b/shell/conf/benchmarks_defaults.conf
@@ -20,25 +20,9 @@
 # Logs
 ALOJA_FORCE_COLORS="1" #Force colors on screen even when writing log files
 
-# Data sizes and default scale factor
-if [ "$BENCH_SCALE_FACTOR" ] ; then
-   BENCH_DATA_SIZE="$(( BENCH_SCALE_FACTOR * 1000000000 ))" #in GB
-else
-   if [ ! "$BENCH_DATA_SIZE" ] ; then
-     # Check if TPC scale factor has been specified
-     if [[ "$TPCH_USE_LOCAL_FACTOR" > 0 ]]; then 
-       BENCH_DATA_SIZE="$(( TPCH_USE_LOCAL_FACTOR *  1000000000 ))" # if set, it is in GBs
-     else
-       if [ "$TPCH_SCALE_FACTOR" ] ; then
-         BENCH_DATA_SIZE="$(( TPCH_SCALE_FACTOR *  1000000000 ))" # if set, it is in GBs
-       else
-         BENCH_DATA_SIZE="100000000" #100MB, in bytes #1000000000000 1TB
-       fi
-     fi
-   fi
+if [ ! "$BENCH_DATA_SIZE" ] ; then
+  set_bench_data_size_bytes "100MB"
 fi
-
-BENCH_SCALE_FACTOR="$(( BENCH_DATA_SIZE / 1000000000 ))" #in GB
 
 # Enable to run multiple times a benchmark, it is useful to repeat a benchmark after a prepare
 [ ! "$BENCH_NUM_RUNS" ] && BENCH_NUM_RUNS=""
@@ -136,10 +120,10 @@ fi
 [ ! "$BB_PARALLEL_STREAMS" ] && BB_PARALLEL_STREAMS="2" #Number of paralel streams for the thoughput test
 [ ! "$BB_MODE" ] && BB_MODE="sequential" # Available options are: squential(default), parallel
 if [ ! "$BB_SCALE_FACTORS" ] ; then
-  if [ "$BENCH_SCALE_FACTOR" == 0 ] ; then
-    BB_SCALE_FACTORS=$((BB_SCALE_FACTORS + 1))
+  if [ "$(get_benchmark_data_size_gb)" -lt 1 ] ; then
+    BB_SCALE_FACTORS=1
   else
-    BB_SCALE_FACTORS=$BENCH_SCALE_FACTOR
+    BB_SCALE_FACTORS="$(get_benchmark_data_size_gb)"
   fi
 fi
 
@@ -199,7 +183,7 @@ fi
 [ ! "$EXECUTOR_CORES" ] && EXECUTOR_CORES="$vmCores" # By default one executor should only use the available physical cores
 [ ! "$EXECUTOR_MEM" ] && EXECUTOR_MEM=$(( MAPS_MB * vmCores )) # in MB
 if [ -z "$SPARK_MEMORY_OVERHEAD" ]; then
-    (( "$BENCH_SCALE_FACTOR" >= 1000 )) && SPARK_MEMORY_OVERHEAD="1024" || SPARK_MEMORY_OVERHEAD="384"
+    (( "$(get_benchmark_data_size_tb)" >= 1 )) && SPARK_MEMORY_OVERHEAD="1024" || SPARK_MEMORY_OVERHEAD="384"
 fi
 
 # Yarn container size


### PR DESCRIPTION
Now a single variable BENCH_DATA_SIZE is used to manage the data
size across all benchmarks. The user can set this variable from
the command line in bytes or size + unit:
BENCH_DATA_SIZE="100000000" #100MB
BENCH_DATA_SIZE="100MB"
BENCH_DATA_SIZE="500GB"
BENCH_DATA_SIZE="10TB"