### PR TITLE
Bugfix/escape characters in template vars

### DIFF
--- a/shell/common/common_benchmarks.sh
+++ b/shell/common/common_benchmarks.sh
@@ -1808,3 +1808,16 @@ get_mounts() {
   fi
   echo -e "$(echo -e "$BENCH_DEVICE_MOUNTS"|cut -d' ' -f2)"
 }
+
+# Creates a perl substitution for a ##TEMPLATE## config variable
+# Usage: create_perl_sub TEMPLATE value [TEMPLATE] [value] ...
+create_perl_template_subs() {
+  if (( $# % 2 != 0 )); then
+    die "${FUNCNAME[0]}: expected an even number of arguments"
+  fi
+
+  while [[ $# -gt  0 ]]; do
+    printf '$r = q/%s/; s/##%s##/$r/g;\n' "${2//\//\\/}" "$1"
+    shift; shift
+  done
+}

--- a/shell/common/common_hive.sh
+++ b/shell/common/common_hive.sh
@@ -166,48 +166,52 @@ get_hive_substitutions() {
   CONTAINER_10="$(echo "${MAPS_MB}*0.10" | bc -l)"
   CONTAINER_10="$(printf "%.0f" $CONTAINER_10)"
 
+  local java_home=$(get_java_home)
+  local hdd=$(get_local_bench_path)
+  local log_dir=$hdd/hive_logs
+
   cat <<EOF
-s,##JAVA_HOME##,$(get_java_home),g;
-s,##HADOOP_HOME##,$BENCH_HADOOP_DIR,g;
-s,##HIVE_CONF_DIR##,$HIVE_CONF_DIR,g;
-s,##JAVA_XMS##,$JAVA_XMS,g;
-s,##JAVA_XMX##,$JAVA_XMX,g;
-s,##JAVA_AM_XMS##,$JAVA_AM_XMS,g;
-s,##JAVA_AM_XMX##,$JAVA_AM_XMX,g;
-s,##LOG_DIR##,$(get_local_bench_path)/hive_logs,g;
-s,##REPLICATION##,$REPLICATION,g;
-s,##MASTER##,$master_name,g;
-s,##NAMENODE##,$master_name,g;
-s,##TMP_DIR##,$HDD_TMP,g;
-s,##HDFS_NDIR##,$HDFS_NDIR,g;
-s,##HDFS_DDIR##,$HDFS_DDIR,g;
-s,##MAX_MAPS##,$MAX_MAPS,g;
-s,##MAX_REDS##,$MAX_REDS,g;
-s,##IFACE##,$IFACE,g;
-s,##IO_FACTOR##,$IO_FACTOR,g;
-s,##IO_MB##,$IO_MB,g;
-s,##JOIN_HIVE##,$JOIN_HIVE,g;
-s,##CONTAINER_80##,$CONTAINER_80,g;
-s,##CONTAINER_40##,$CONTAINER_40,g;
-s,##CONTAINER_10##,$CONTAINER_10,g;
-s,##PORT_PREFIX##,$PORT_PREFIX,g;
-s,##IO_FILE##,$IO_FILE,g;
-s,##BLOCK_SIZE##,$BLOCK_SIZE,g;
-s,##PHYS_MEM##,$PHYS_MEM,g;
-s,##NUM_CORES##,$NUM_CORES,g;
-s,##CONTAINER_MIN_MB##,$CONTAINER_MIN_MB,g;
-s,##CONTAINER_MAX_MB##,$CONTAINER_MAX_MB,g;
-s,##MAPS_MB##,$MAPS_MB,g;
-s,##REDUCES_MB##,$REDUCES_MB,g;
-s,##AM_MB##,$AM_MB,g;
-s,##BENCH_LOCAL_DIR##,$BENCH_LOCAL_DIR,g;
-s,##HDD##,$(get_local_bench_path),g;
-s,##HIVE_ENGINE##,$HIVE_ENGINE,g;
-s,##HIVE_JOINS##,$HIVE_JOINS,g;
-s,##DATABASE_DRIVER##,$database_driver,g;
-s,##DATABASE_DRIVER_NAME##,$database_driver_name,g;
-s,##URL##,$url,g;
-s{##EXPERIMENT_ID##}{\Q$EXPERIMENT_ID\E}g;
+\$r = q/${java_home//\//\\/}/;            s/##JAVA_HOME##/\$r/g;
+\$r = q/${BENCH_HADOOP_DIR//\//\\/}/;     s/##HADOOP_HOME##/\$r/g;
+\$r = q/${HIVE_CONF_DIR//\//\\/}/;        s/##HIVE_CONF_DIR##/\$r/g;
+\$r = q/${JAVA_XMS//\//\\/}/;             s/##JAVA_XMS##/\$r/g;
+\$r = q/${JAVA_XMX//\//\\/}/;             s/##JAVA_XMX##/\$r/g;
+\$r = q/${JAVA_AM_XMS//\//\\/}/;          s/##JAVA_AM_XMS##/\$r/g;
+\$r = q/${JAVA_AM_XMX//\//\\/}/;          s/##JAVA_AM_XMX##/\$r/g;
+\$r = q/${log_dir//\//\\/}/;              s/##LOG_DIR##/\$r/g;
+\$r = q/${REPLICATION//\//\\/}/;          s/##REPLICATION##/\$r/g;
+\$r = q/${master_name//\//\\/}/;          s/##MASTER##/\$r/g;
+\$r = q/${master_name//\//\\/}/;          s/##NAMENODE##/\$r/g;
+\$r = q/${HDD_TMP//\//\\/}/;              s/##TMP_DIR##/\$r/g;
+\$r = q/${HDFS_NDIR//\//\\/}/;            s/##HDFS_NDIR##/\$r/g;
+\$r = q/${HDFS_DDIR//\//\\/}/;            s/##HDFS_DDIR##/\$r/g;
+\$r = q/${MAX_MAPS//\//\\/}/;             s/##MAX_MAPS##/\$r/g;
+\$r = q/${MAX_REDS//\//\\/}/;             s/##MAX_REDS##/\$r/g;
+\$r = q/${IFACE//\//\\/}/;                s/##IFACE##/\$r/g;
+\$r = q/${IO_FACTOR//\//\\/}/;            s/##IO_FACTOR##/\$r/g;
+\$r = q/${IO_MB//\//\\/}/;                s/##IO_MB##/\$r/g;
+\$r = q/${JOIN_HIVE//\//\\/}/;            s/##JOIN_HIVE##/\$r/g;
+\$r = q/${CONTAINER_80//\//\\/}/;         s/##CONTAINER_80##/\$r/g;
+\$r = q/${CONTAINER_40//\//\\/}/;         s/##CONTAINER_40##/\$r/g;
+\$r = q/${CONTAINER_10//\//\\/}/;         s/##CONTAINER_10##/\$r/g;
+\$r = q/${PORT_PREFIX//\//\\/}/;          s/##PORT_PREFIX##/\$r/g;
+\$r = q/${IO_FILE//\//\\/}/;              s/##IO_FILE##/\$r/g;
+\$r = q/${BLOCK_SIZE//\//\\/}/;           s/##BLOCK_SIZE##/\$r/g;
+\$r = q/${PHYS_MEM//\//\\/}/;             s/##PHYS_MEM##/\$r/g;
+\$r = q/${NUM_CORES//\//\\/}/;            s/##NUM_CORES##/\$r/g;
+\$r = q/${CONTAINER_MIN_MB//\//\\/}/;     s/##CONTAINER_MIN_MB##/\$r/g;
+\$r = q/${CONTAINER_MAX_MB//\//\\/}/;     s/##CONTAINER_MAX_MB##/\$r/g;
+\$r = q/${MAPS_MB//\//\\/}/;              s/##MAPS_MB##/\$r/g;
+\$r = q/${REDUCES_MB//\//\\/}/;           s/##REDUCES_MB##/\$r/g;
+\$r = q/${AM_MB//\//\\/}/;                s/##AM_MB##/\$r/g;
+\$r = q/${BENCH_LOCAL_DIR//\//\\/}/;      s/##BENCH_LOCAL_DIR##/\$r/g;
+\$r = q/${hdd//\//\\/}/;                  s/##HDD##/\$r/g;
+\$r = q/${HIVE_ENGINE//\//\\/}/;          s/##HIVE_ENGINE##/\$r/g;
+\$r = q/${HIVE_JOINS//\//\\/}/;           s/##HIVE_JOINS##/\$r/g;
+\$r = q/${database_driver//\//\\/}/;      s/##DATABASE_DRIVER##/\$r/g;
+\$r = q/${database_driver_name//\//\\/}/; s/##DATABASE_DRIVER_NAME##/\$r/g;
+\$r = q/${url//\//\\/}/;                  s/##URL##/\$r/g;
+\$r = q/${EXPERIMENT_ID//\//\\/}/;        s/##EXPERIMENT_ID##/\$r/g;
 EOF
 }
 

--- a/shell/common/common_hive.sh
+++ b/shell/common/common_hive.sh
@@ -166,53 +166,51 @@ get_hive_substitutions() {
   CONTAINER_10="$(echo "${MAPS_MB}*0.10" | bc -l)"
   CONTAINER_10="$(printf "%.0f" $CONTAINER_10)"
 
-  local java_home=$(get_java_home)
   local hdd=$(get_local_bench_path)
   local log_dir=$hdd/hive_logs
 
-  cat <<EOF
-\$r = q/${java_home//\//\\/}/;            s/##JAVA_HOME##/\$r/g;
-\$r = q/${BENCH_HADOOP_DIR//\//\\/}/;     s/##HADOOP_HOME##/\$r/g;
-\$r = q/${HIVE_CONF_DIR//\//\\/}/;        s/##HIVE_CONF_DIR##/\$r/g;
-\$r = q/${JAVA_XMS//\//\\/}/;             s/##JAVA_XMS##/\$r/g;
-\$r = q/${JAVA_XMX//\//\\/}/;             s/##JAVA_XMX##/\$r/g;
-\$r = q/${JAVA_AM_XMS//\//\\/}/;          s/##JAVA_AM_XMS##/\$r/g;
-\$r = q/${JAVA_AM_XMX//\//\\/}/;          s/##JAVA_AM_XMX##/\$r/g;
-\$r = q/${log_dir//\//\\/}/;              s/##LOG_DIR##/\$r/g;
-\$r = q/${REPLICATION//\//\\/}/;          s/##REPLICATION##/\$r/g;
-\$r = q/${master_name//\//\\/}/;          s/##MASTER##/\$r/g;
-\$r = q/${master_name//\//\\/}/;          s/##NAMENODE##/\$r/g;
-\$r = q/${HDD_TMP//\//\\/}/;              s/##TMP_DIR##/\$r/g;
-\$r = q/${HDFS_NDIR//\//\\/}/;            s/##HDFS_NDIR##/\$r/g;
-\$r = q/${HDFS_DDIR//\//\\/}/;            s/##HDFS_DDIR##/\$r/g;
-\$r = q/${MAX_MAPS//\//\\/}/;             s/##MAX_MAPS##/\$r/g;
-\$r = q/${MAX_REDS//\//\\/}/;             s/##MAX_REDS##/\$r/g;
-\$r = q/${IFACE//\//\\/}/;                s/##IFACE##/\$r/g;
-\$r = q/${IO_FACTOR//\//\\/}/;            s/##IO_FACTOR##/\$r/g;
-\$r = q/${IO_MB//\//\\/}/;                s/##IO_MB##/\$r/g;
-\$r = q/${JOIN_HIVE//\//\\/}/;            s/##JOIN_HIVE##/\$r/g;
-\$r = q/${CONTAINER_80//\//\\/}/;         s/##CONTAINER_80##/\$r/g;
-\$r = q/${CONTAINER_40//\//\\/}/;         s/##CONTAINER_40##/\$r/g;
-\$r = q/${CONTAINER_10//\//\\/}/;         s/##CONTAINER_10##/\$r/g;
-\$r = q/${PORT_PREFIX//\//\\/}/;          s/##PORT_PREFIX##/\$r/g;
-\$r = q/${IO_FILE//\//\\/}/;              s/##IO_FILE##/\$r/g;
-\$r = q/${BLOCK_SIZE//\//\\/}/;           s/##BLOCK_SIZE##/\$r/g;
-\$r = q/${PHYS_MEM//\//\\/}/;             s/##PHYS_MEM##/\$r/g;
-\$r = q/${NUM_CORES//\//\\/}/;            s/##NUM_CORES##/\$r/g;
-\$r = q/${CONTAINER_MIN_MB//\//\\/}/;     s/##CONTAINER_MIN_MB##/\$r/g;
-\$r = q/${CONTAINER_MAX_MB//\//\\/}/;     s/##CONTAINER_MAX_MB##/\$r/g;
-\$r = q/${MAPS_MB//\//\\/}/;              s/##MAPS_MB##/\$r/g;
-\$r = q/${REDUCES_MB//\//\\/}/;           s/##REDUCES_MB##/\$r/g;
-\$r = q/${AM_MB//\//\\/}/;                s/##AM_MB##/\$r/g;
-\$r = q/${BENCH_LOCAL_DIR//\//\\/}/;      s/##BENCH_LOCAL_DIR##/\$r/g;
-\$r = q/${hdd//\//\\/}/;                  s/##HDD##/\$r/g;
-\$r = q/${HIVE_ENGINE//\//\\/}/;          s/##HIVE_ENGINE##/\$r/g;
-\$r = q/${HIVE_JOINS//\//\\/}/;           s/##HIVE_JOINS##/\$r/g;
-\$r = q/${database_driver//\//\\/}/;      s/##DATABASE_DRIVER##/\$r/g;
-\$r = q/${database_driver_name//\//\\/}/; s/##DATABASE_DRIVER_NAME##/\$r/g;
-\$r = q/${url//\//\\/}/;                  s/##URL##/\$r/g;
-\$r = q/${EXPERIMENT_ID//\//\\/}/;        s/##EXPERIMENT_ID##/\$r/g;
-EOF
+  create_perl_template_subs \
+    JAVA_HOME "$(get_java_home)" \
+    HADOOP_HOME "$BENCH_HADOOP_DIR" \
+    HIVE_CONF_DIR "$HIVE_CONF_DIR" \
+    JAVA_XMS "$JAVA_XMS" \
+    JAVA_XMX "$JAVA_XMX" \
+    JAVA_AM_XMS "$JAVA_AM_XMS" \
+    JAVA_AM_XMX "$JAVA_AM_XMX" \
+    LOG_DIR "$log_dir" \
+    REPLICATION "$REPLICATION" \
+    MASTER "$master_name" \
+    NAMENODE "$master_name" \
+    TMP_DIR "$HDD_TMP" \
+    HDFS_NDIR "$HDFS_NDIR" \
+    HDFS_DDIR "$HDFS_DDIR" \
+    MAX_MAPS "$MAX_MAPS" \
+    MAX_REDS "$MAX_REDS" \
+    IFACE "$IFACE" \
+    IO_FACTOR "$IO_FACTOR" \
+    IO_MB "$IO_MB" \
+    JOIN_HIVE "$JOIN_HIVE" \
+    CONTAINER_80 "$CONTAINER_80" \
+    CONTAINER_40 "$CONTAINER_40" \
+    CONTAINER_10 "$CONTAINER_10" \
+    PORT_PREFIX "$PORT_PREFIX" \
+    IO_FILE "$IO_FILE" \
+    BLOCK_SIZE "$BLOCK_SIZE" \
+    PHYS_MEM "$PHYS_MEM" \
+    NUM_CORES "$NUM_CORES" \
+    CONTAINER_MIN_MB "$CONTAINER_MIN_MB" \
+    CONTAINER_MAX_MB "$CONTAINER_MAX_MB" \
+    MAPS_MB "$MAPS_MB" \
+    REDUCES_MB "$REDUCES_MB" \
+    AM_MB "$AM_MB" \
+    BENCH_LOCAL_DIR "$BENCH_LOCAL_DIR" \
+    HDD "$hdd" \
+    HIVE_ENGINE "$HIVE_ENGINE" \
+    HIVE_JOINS "$HIVE_JOINS" \
+    DATABASE_DRIVER "$database_driver" \
+    DATABASE_DRIVER_NAME "$database_driver_name" \
+    URL "$url" \
+    EXPERIMENT_ID "$EXPERIMENT_ID"
 }
 
 get_hive_conf_dir() {

--- a/shell/common/common_spark.sh
+++ b/shell/common/common_spark.sh
@@ -154,59 +154,51 @@ get_spark_substitutions() {
 
   local java_home=$(get_java_home)
   local hdd=$(get_local_bench_path)
-  local log_dir=$hdd/spark_logs
-  local hdfs_path=$hdd/bench_data
 
-  local hive=$HIVE_HOME/bin/hive
-  local spark_executor_extra_classpath=$HIVE_HOME/lib/:$HIVE_CONF_DIR
-  local hadoop_libs=$BENCH_HADOOP_DIR/lib/native
-  local spark=$SPARK_HOME/bin/spark
-
-  cat <<EOF
-\$r = q/${java_home//\//\\/}/;                     s/##JAVA_HOME##/\$r/g;
-\$r = q/${BENCH_HADOOP_DIR//\//\\/}/;              s/##HADOOP_HOME##/\$r/g;
-\$r = q/${JAVA_XMS//\//\\/}/;                      s/##JAVA_XMS##/\$r/g;
-\$r = q/${JAVA_XMX//\//\\/}/;                      s/##JAVA_XMX##/\$r/g;
-\$r = q/${JAVA_AM_XMS//\//\\/}/;                   s/##JAVA_AM_XMS##/\$r/g;
-\$r = q/${JAVA_AM_XMX//\//\\/}/;                   s/##JAVA_AM_XMX##/\$r/g;
-\$r = q/${log_dir//\//\\/}/;                       s/##LOG_DIR##/\$r/g;
-\$r = q/${REPLICATION//\//\\/}/;                   s/##REPLICATION##/\$r/g;
-\$r = q/${master_name//\//\\/}/;                   s/##MASTER##/\$r/g;
-\$r = q/${master_name//\//\\/}/;                   s/##NAMENODE##/\$r/g;
-\$r = q/${HDD_TMP//\//\\/}/;                       s/##TMP_DIR##/\$r/g;
-\$r = q/${HDFS_NDIR//\//\\/}/;                     s/##HDFS_NDIR##/\$r/g;
-\$r = q/${HDFS_DDIR//\//\\/}/;                     s/##HDFS_DDIR##/\$r/g;
-\$r = q/${MAX_MAPS//\//\\/}/;                      s/##MAX_MAPS##/\$r/g;
-\$r = q/${MAX_REDS//\//\\/}/;                      s/##MAX_REDS##/\$r/g;
-\$r = q/${IFACE//\//\\/}/;                         s/##IFACE##/\$r/g;
-\$r = q/${IO_FACTOR//\//\\/}/;                     s/##IO_FACTOR##/\$r/g;
-\$r = q/${IO_MB//\//\\/}/;                         s/##IO_MB##/\$r/g;
-\$r = q/${PORT_PREFIX//\//\\/}/;                   s/##PORT_PREFIX##/\$r/g;
-\$r = q/${IO_FILE//\//\\/}/;                       s/##IO_FILE##/\$r/g;
-\$r = q/${BLOCK_SIZE//\//\\/}/;                    s/##BLOCK_SIZE##/\$r/g;
-\$r = q/${PHYS_MEM//\//\\/}/;                      s/##PHYS_MEM##/\$r/g;
-\$r = q/${NUM_CORES//\//\\/}/;                     s/##NUM_CORES##/\$r/g;
-\$r = q/${CONTAINER_MIN_MB//\//\\/}/;              s/##CONTAINER_MIN_MB##/\$r/g;
-\$r = q/${CONTAINER_MAX_MB//\//\\/}/;              s/##CONTAINER_MAX_MB##/\$r/g;
-\$r = q/${MAPS_MB//\//\\/}/;                       s/##MAPS_MB##/\$r/g;
-\$r = q/${REDUCES_MB//\//\\/}/;                    s/##REDUCES_MB##/\$r/g;
-\$r = q/${AM_MB//\//\\/}/;                         s/##AM_MB##/\$r/g;
-\$r = q/${BENCH_LOCAL_DIR//\//\\/}/;               s/##BENCH_LOCAL_DIR##/\$r/g;
-\$r = q/${hdd//\//\\/}/;                           s/##HDD##/\$r/g;
-\$r = q/${hive//\//\/}/;                           s/##HIVE##/$hive/g
-\$r = q/${spark_executor_extra_classpath//\//\/}/; s/##SPARK_EXECUTOR_EXTRA_CLASSPATH##/\$r/g
-\$r = q/${hdfs_path//\//\/}/;                      s/##HDFS_PATH##/\$r/g
-\$r = q/${HADOOP_CONF_DIR//\//\/}/;                s/##HADOOP_CONF##/\$r/g
-\$r = q/${hadoop_libs//\//\/}/;                    s/##HADOOP_LIBS##/\$r/g
-\$r = q/${spark//\//\/}/;                          s/##SPARK##/\$r/g
-\$r = q/${SPARK_CONF_DIR//\//\/}/;                 s/##SPARK_CONF##/\$r/g
-\$r = q/${EXECUTOR_INSTANCES//\//\/}/;             s/##EXECUTOR_INSTANCES##/\$r/g
-\$r = q/${EXECUTOR_CORES//\//\/}/;                 s/##EXECUTOR_CORES##/\$r/g
-\$r = q/${SPARK_MAJOR_VERSION//\//\/}/;            s/##SPARK_MAJOR_VERSION##/\$r/g
-\$r = q/${SPARK_MEMORY_OVERHEAD//\//\/}/;          s/##SPARK_MEMORY_OVERHEAD##/\$r/g
-\$r = q/${EXECUTOR_MEM//\//\/}/;                   s/##EXECUTOR_MEM##/\$r/g
-\$r = q/${EXPERIMENT_ID//\//\\/}/;                 s/##EXPERIMENT_ID##/\$r/g;
-EOF
+  create_perl_template_subs \
+    JAVA_HOME "$java_home" \
+    HADOOP_HOME "$BENCH_HADOOP_DIR" \
+    JAVA_XMS "$JAVA_XMS" \
+    JAVA_XMX "$JAVA_XMX" \
+    JAVA_AM_XMS "$JAVA_AM_XMS" \
+    JAVA_AM_XMX "$JAVA_AM_XMX" \
+    LOG_DIR "$hdd/spark_logs" \
+    REPLICATION "$REPLICATION" \
+    MASTER "$master_name" \
+    NAMENODE "$master_name" \
+    TMP_DIR "$HDD_TMP" \
+    HDFS_NDIR "$HDFS_NDIR" \
+    HDFS_DDIR "$HDFS_DDIR" \
+    MAX_MAPS "$MAX_MAPS" \
+    MAX_REDS "$MAX_REDS" \
+    IFACE "$IFACE" \
+    IO_FACTOR "$IO_FACTOR" \
+    IO_MB "$IO_MB" \
+    PORT_PREFIX "$PORT_PREFIX" \
+    IO_FILE "$IO_FILE" \
+    BLOCK_SIZE "$BLOCK_SIZE" \
+    PHYS_MEM "$PHYS_MEM" \
+    NUM_CORES "$NUM_CORES" \
+    CONTAINER_MIN_MB "$CONTAINER_MIN_MB" \
+    CONTAINER_MAX_MB "$CONTAINER_MAX_MB" \
+    MAPS_MB "$MAPS_MB" \
+    REDUCES_MB "$REDUCES_MB" \
+    AM_MB "$AM_MB" \
+    BENCH_LOCAL_DIR "$BENCH_LOCAL_DIR" \
+    HDD "$hdd" \
+    HIVE "$HIVE_HOME/bin/hive" \
+    SPARK_EXECUTOR_EXTRA_CLASSPATH "$HIVE_HOME/lib/:$HIVE_CONF_DIR" \
+    HDFS_PATH "$hdd/bench_data" \
+    HADOOP_CONF "$HADOOP_CONF_DIR" \
+    HADOOP_LIBS "$BENCH_HADOOP_DIR/lib/native" \
+    SPARK "$SPARK_HOME/bin/spark" \
+    SPARK_CONF "$SPARK_CONF_DIR" \
+    EXECUTOR_INSTANCES "$EXECUTOR_INSTANCES" \
+    EXECUTOR_CORES "$EXECUTOR_CORES" \
+    SPARK_MAJOR_VERSION "$SPARK_MAJOR_VERSION" \
+    SPARK_MEMORY_OVERHEAD "$SPARK_MEMORY_OVERHEAD" \
+    EXECUTOR_MEM "$EXECUTOR_MEM" \
+    EXPERIMENT_ID "$EXPERIMENT_ID"
 }
 
 get_spark_conf_dir() {

--- a/shell/common/common_spark.sh
+++ b/shell/common/common_spark.sh
@@ -152,50 +152,60 @@ get_spark_substitutions() {
 
   [ ! "$SPARK_MAJOR_VERSION" ] && SPARK_MAJOR_VERSION="0"
 
+  local java_home=$(get_java_home)
+  local hdd=$(get_local_bench_path)
+  local log_dir=$hdd/spark_logs
+  local hdfs_path=$hdd/bench_data
+
+  local hive=$HIVE_HOME/bin/hive
+  local spark_executor_extra_classpath=$HIVE_HOME/lib/:$HIVE_CONF_DIR
+  local hadoop_libs=$BENCH_HADOOP_DIR/lib/native
+  local spark=$SPARK_HOME/bin/spark
+
   cat <<EOF
-s,##JAVA_HOME##,$(get_java_home),g;
-s,##HADOOP_HOME##,$BENCH_HADOOP_DIR,g;
-s,##JAVA_XMS##,$JAVA_XMS,g;
-s,##JAVA_XMX##,$JAVA_XMX,g;
-s,##JAVA_AM_XMS##,$JAVA_AM_XMS,g;
-s,##JAVA_AM_XMX##,$JAVA_AM_XMX,g;
-s,##LOG_DIR##,$HDD/spark_logs,g;
-s,##REPLICATION##,$REPLICATION,g;
-s,##MASTER##,$master_name,g;
-s,##NAMENODE##,$master_name,g;
-s,##TMP_DIR##,$HDD_TMP,g;
-s,##HDFS_NDIR##,$HDFS_NDIR,g;
-s,##HDFS_DDIR##,$HDFS_DDIR,g;
-s,##MAX_MAPS##,$MAX_MAPS,g;
-s,##MAX_REDS##,$MAX_REDS,g;
-s,##IFACE##,$IFACE,g;
-s,##IO_FACTOR##,$IO_FACTOR,g;
-s,##IO_MB##,$IO_MB,g;
-s,##PORT_PREFIX##,$PORT_PREFIX,g;
-s,##IO_FILE##,$IO_FILE,g;
-s,##BLOCK_SIZE##,$BLOCK_SIZE,g;
-s,##PHYS_MEM##,$PHYS_MEM,g;
-s,##NUM_CORES##,$NUM_CORES,g;
-s,##CONTAINER_MIN_MB##,$CONTAINER_MIN_MB,g;
-s,##CONTAINER_MAX_MB##,$CONTAINER_MAX_MB,g;
-s,##MAPS_MB##,$MAPS_MB,g;
-s,##REDUCES_MB##,$REDUCES_MB,g;
-s,##AM_MB##,$AM_MB,g;
-s,##BENCH_LOCAL_DIR##,$BENCH_LOCAL_DIR,g;
-s,##HDD##,$(get_local_bench_path),g;
-s,##HIVE##,$HIVE_HOME/bin/hive,g;
-s,##SPARK_EXECUTOR_EXTRA_CLASSPATH##,$HIVE_HOME/lib/:$HIVE_CONF_DIR,g;
-s,##HDFS_PATH##,$(get_local_bench_path)/bench_data,g;
-s,##HADOOP_CONF##,$HADOOP_CONF_DIR,g;
-s,##HADOOP_LIBS##,$BENCH_HADOOP_DIR/lib/native,g;
-s,##SPARK##,$SPARK_HOME/bin/spark,g;
-s,##SPARK_CONF##,$SPARK_CONF_DIR,g;
-s,##EXECUTOR_INSTANCES##,$EXECUTOR_INSTANCES,g;
-s,##EXECUTOR_CORES##,$EXECUTOR_CORES,g;
-s,##SPARK_MAJOR_VERSION##,$SPARK_MAJOR_VERSION,g;
-s,##SPARK_MEMORY_OVERHEAD##,$SPARK_MEMORY_OVERHEAD,g;
-s,##EXECUTOR_MEM##,$EXECUTOR_MEM,g;
-s{##EXPERIMENT_ID##}{\Q$EXPERIMENT_ID\E};
+\$r = q/${java_home//\//\\/}/;                     s/##JAVA_HOME##/\$r/g;
+\$r = q/${BENCH_HADOOP_DIR//\//\\/}/;              s/##HADOOP_HOME##/\$r/g;
+\$r = q/${JAVA_XMS//\//\\/}/;                      s/##JAVA_XMS##/\$r/g;
+\$r = q/${JAVA_XMX//\//\\/}/;                      s/##JAVA_XMX##/\$r/g;
+\$r = q/${JAVA_AM_XMS//\//\\/}/;                   s/##JAVA_AM_XMS##/\$r/g;
+\$r = q/${JAVA_AM_XMX//\//\\/}/;                   s/##JAVA_AM_XMX##/\$r/g;
+\$r = q/${log_dir//\//\\/}/;                       s/##LOG_DIR##/\$r/g;
+\$r = q/${REPLICATION//\//\\/}/;                   s/##REPLICATION##/\$r/g;
+\$r = q/${master_name//\//\\/}/;                   s/##MASTER##/\$r/g;
+\$r = q/${master_name//\//\\/}/;                   s/##NAMENODE##/\$r/g;
+\$r = q/${HDD_TMP//\//\\/}/;                       s/##TMP_DIR##/\$r/g;
+\$r = q/${HDFS_NDIR//\//\\/}/;                     s/##HDFS_NDIR##/\$r/g;
+\$r = q/${HDFS_DDIR//\//\\/}/;                     s/##HDFS_DDIR##/\$r/g;
+\$r = q/${MAX_MAPS//\//\\/}/;                      s/##MAX_MAPS##/\$r/g;
+\$r = q/${MAX_REDS//\//\\/}/;                      s/##MAX_REDS##/\$r/g;
+\$r = q/${IFACE//\//\\/}/;                         s/##IFACE##/\$r/g;
+\$r = q/${IO_FACTOR//\//\\/}/;                     s/##IO_FACTOR##/\$r/g;
+\$r = q/${IO_MB//\//\\/}/;                         s/##IO_MB##/\$r/g;
+\$r = q/${PORT_PREFIX//\//\\/}/;                   s/##PORT_PREFIX##/\$r/g;
+\$r = q/${IO_FILE//\//\\/}/;                       s/##IO_FILE##/\$r/g;
+\$r = q/${BLOCK_SIZE//\//\\/}/;                    s/##BLOCK_SIZE##/\$r/g;
+\$r = q/${PHYS_MEM//\//\\/}/;                      s/##PHYS_MEM##/\$r/g;
+\$r = q/${NUM_CORES//\//\\/}/;                     s/##NUM_CORES##/\$r/g;
+\$r = q/${CONTAINER_MIN_MB//\//\\/}/;              s/##CONTAINER_MIN_MB##/\$r/g;
+\$r = q/${CONTAINER_MAX_MB//\//\\/}/;              s/##CONTAINER_MAX_MB##/\$r/g;
+\$r = q/${MAPS_MB//\//\\/}/;                       s/##MAPS_MB##/\$r/g;
+\$r = q/${REDUCES_MB//\//\\/}/;                    s/##REDUCES_MB##/\$r/g;
+\$r = q/${AM_MB//\//\\/}/;                         s/##AM_MB##/\$r/g;
+\$r = q/${BENCH_LOCAL_DIR//\//\\/}/;               s/##BENCH_LOCAL_DIR##/\$r/g;
+\$r = q/${hdd//\//\\/}/;                           s/##HDD##/\$r/g;
+\$r = q/${hive//\//\/}/;                           s/##HIVE##/$hive/g
+\$r = q/${spark_executor_extra_classpath//\//\/}/; s/##SPARK_EXECUTOR_EXTRA_CLASSPATH##/\$r/g
+\$r = q/${hdfs_path//\//\/}/;                      s/##HDFS_PATH##/\$r/g
+\$r = q/${HADOOP_CONF_DIR//\//\/}/;                s/##HADOOP_CONF##/\$r/g
+\$r = q/${hadoop_libs//\//\/}/;                    s/##HADOOP_LIBS##/\$r/g
+\$r = q/${spark//\//\/}/;                          s/##SPARK##/\$r/g
+\$r = q/${SPARK_CONF_DIR//\//\/}/;                 s/##SPARK_CONF##/\$r/g
+\$r = q/${EXECUTOR_INSTANCES//\//\/}/;             s/##EXECUTOR_INSTANCES##/\$r/g
+\$r = q/${EXECUTOR_CORES//\//\/}/;                 s/##EXECUTOR_CORES##/\$r/g
+\$r = q/${SPARK_MAJOR_VERSION//\//\/}/;            s/##SPARK_MAJOR_VERSION##/\$r/g
+\$r = q/${SPARK_MEMORY_OVERHEAD//\//\/}/;          s/##SPARK_MEMORY_OVERHEAD##/\$r/g
+\$r = q/${EXECUTOR_MEM//\//\/}/;                   s/##EXECUTOR_MEM##/\$r/g
+\$r = q/${EXPERIMENT_ID//\//\\/}/;                 s/##EXPERIMENT_ID##/\$r/g;
 EOF
 }
 

--- a/shell/test/README.md
+++ b/shell/test/README.md
@@ -1,0 +1,7 @@
+# Running tests
+
+Run all the tests in the current directory like this:
+
+```
+bats-core/bin/bats .
+```

--- a/shell/test/create_perl_template_subs.bats
+++ b/shell/test/create_perl_template_subs.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+
+. ../common/common_benchmarks.sh
+
+java_home='../$trange/p@th/t0/my app'
+
+@test "creates the expected perl string" {
+    run create_perl_template_subs JAVA_HOME "$java_home"
+    expected='$r = q/..\/$trange\/p@th\/t0\/my app/; s/##JAVA_HOME##/$r/g;'
+    [ "$status" -eq 0 ]
+    [ "$output" = "$expected" ]
+}
+
+@test "fails when an odd number of arguments are passed" {
+    run create_perl_template_subs one_arg
+    [ "$status" -ne 0 ]
+}
+
+@test "performs the expected substitution" {
+    input='(start)##JAVA_HOME##(end)'
+    run perl -pe "$(create_perl_template_subs JAVA_HOME "$java_home")" <<<"$input"
+    expected="(start)$java_home(end)"
+    [ "$output" = "$expected" ]
+}
+
+@test "performs more than one set of substitution" {
+    input='(first)##JAVA_HOME##'$'\n''(second)##JAVA_HOME##'
+    run perl -pe "$(create_perl_template_subs JAVA_HOME "$java_home")" <<<"$input"
+    expected="(first)$java_home"$'\n'"(second)$java_home"
+    [ "$output" = "$expected" ]
+}


### PR DESCRIPTION
As far as I can tell, the issue is fixed and the syntax is simplified for the calling code. I only changed the places that were affected by the original issue, which was related to the ##EXPERIMENT_ID## template variable. If people are happy with the changes, we can use this function elsewhere too.

Feedback regarding the location of the utility function, and unit test suite are welcome, as I didn't really know where to put either of them.

Also, I think it should be considered a fatal error if the function is called with the incorrect number of args, but I wasn't sure if a call to `exit` was a good idea.