### PR TITLE
Add bats-core binaries for automatic bash testing

### DIFF
--- a/shell/test/bats-core/bin/bats
+++ b/shell/test/bats-core/bin/bats
@@ -1,0 +1,1 @@
+../libexec/bats

--- a/shell/test/bats-core/libexec/bats
+++ b/shell/test/bats-core/libexec/bats
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -e
+
+version() {
+  echo "Bats 0.4.0"
+}
+
+usage() {
+  version
+  echo "Usage: bats [-c] [-p | -t] <test> [<test> ...]"
+}
+
+help() {
+  usage
+  echo
+  echo "  <test> is the path to a Bats test file, or the path to a directory"
+  echo "  containing Bats test files."
+  echo
+  echo "  -c, --count    Count the number of test cases without running any tests"
+  echo "  -h, --help     Display this help message"
+  echo "  -p, --pretty   Show results in pretty format (default for terminals)"
+  echo "  -t, --tap      Show results in TAP format"
+  echo "  -v, --version  Display the version number"
+  echo
+  echo "  For more information, see https://github.com/bats-core/bats-core"
+  echo
+}
+
+BATS_READLINK=
+
+resolve_link() {
+  if [[ -z "$BATS_READLINK" ]]; then
+    if command -v 'greadlink' >/dev/null; then
+      BATS_READLINK='greadlink'
+    elif command -v 'readlink' >/dev/null; then
+      BATS_READLINK='readlink'
+    else
+      BATS_READLINK='true'
+    fi
+  fi
+  "$BATS_READLINK" "$1" || return 0
+}
+
+abs_dirname() {
+  local cwd="$PWD"
+  local path="$1"
+
+  while [ -n "$path" ]; do
+    cd "${path%/*}"
+    local name="${path##*/}"
+    path="$(resolve_link "$name")"
+  done
+
+  printf -v "$2" -- '%s' "$PWD"
+  cd "$cwd"
+}
+
+expand_path() {
+  local path="${1%/}"
+  local dirname="${path%/*}"
+
+  if [[ "$dirname" == "$path" ]]; then
+    dirname="$PWD"
+  elif cd "$dirname" 2>/dev/null; then
+    dirname="$PWD"
+    cd "$OLDPWD"
+  else
+    printf '%s' "$path"
+    return
+  fi
+  printf -v "$2" '%s/%s' "$dirname" "${path##*/}"
+}
+
+abs_dirname "$0" 'BATS_LIBEXEC'
+abs_dirname "$BATS_LIBEXEC" 'BATS_PREFIX'
+abs_dirname '.' 'BATS_CWD'
+
+export BATS_PREFIX
+export BATS_CWD
+export BATS_TEST_PATTERN="^[[:blank:]]*@test[[:blank:]]+(.*[^[:blank:]])[[:blank:]]+\{(.*)\$"
+export PATH="$BATS_LIBEXEC:$PATH"
+
+options=()
+arguments=()
+for arg in "$@"; do
+  if [ "${arg:0:1}" = "-" ]; then
+    if [ "${arg:1:1}" = "-" ]; then
+      options[${#options[*]}]="${arg:2}"
+    else
+      index=1
+      while option="${arg:$index:1}"; do
+        [ -n "$option" ] || break
+        options[${#options[*]}]="$option"
+        let index+=1
+      done
+    fi
+  else
+    arguments[${#arguments[*]}]="$arg"
+  fi
+done
+
+unset count_flag pretty
+count_flag=''
+pretty=''
+[ -t 0 ] && [ -t 1 ] && pretty="1"
+[ -n "${CI:-}" ] && pretty=""
+
+if [[ "${#options[@]}" -ne '0' ]]; then
+  for option in "${options[@]}"; do
+    case "$option" in
+    "h" | "help" )
+      help
+      exit 0
+      ;;
+    "v" | "version" )
+      version
+      exit 0
+      ;;
+    "c" | "count" )
+      count_flag="-c"
+      ;;
+    "t" | "tap" )
+      pretty=""
+      ;;
+    "p" | "pretty" )
+      pretty="1"
+      ;;
+    * )
+      usage >&2
+      exit 1
+      ;;
+    esac
+  done
+fi
+
+if [ "${#arguments[@]}" -eq 0 ]; then
+  usage >&2
+  exit 1
+fi
+
+filenames=()
+for filename in "${arguments[@]}"; do
+  expand_path "$filename" 'filename'
+
+  if [ -d "$filename" ]; then
+    shopt -s nullglob
+    for suite_filename in "$filename"/*.bats; do
+      filenames["${#filenames[@]}"]="$suite_filename"
+    done
+    shopt -u nullglob
+  else
+    filenames["${#filenames[@]}"]="$filename"
+  fi
+done
+
+if [ "${#filenames[@]}" -eq 1 ]; then
+  command="bats-exec-test"
+else
+  command="bats-exec-suite"
+fi
+
+set -o pipefail execfail
+if [ -z "$pretty" ]; then
+  exec "$command" $count_flag "${filenames[@]}"
+else
+  extended_syntax_flag="-x"
+  formatter="bats-format-tap-stream"
+  exec "$command" $count_flag $extended_syntax_flag "${filenames[@]}" | "$formatter"
+fi

--- a/shell/test/bats-core/libexec/bats-exec-suite
+++ b/shell/test/bats-core/libexec/bats-exec-suite
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -e
+
+count_only_flag=""
+if [ "$1" = "-c" ]; then
+  count_only_flag=1
+  shift
+fi
+
+extended_syntax_flag=""
+if [ "$1" = "-x" ]; then
+  extended_syntax_flag="-x"
+  shift
+fi
+
+trap "kill 0; exit 1" int
+
+count=0
+for filename in "$@"; do
+  while IFS= read -r line; do
+    if [[ "$line" =~ $BATS_TEST_PATTERN ]]; then
+      let count+=1
+    fi
+  done <"$filename"
+done
+
+if [ -n "$count_only_flag" ]; then
+  echo "$count"
+  exit
+fi
+
+echo "1..$count"
+status=0
+offset=0
+for filename in "$@"; do
+  index=0
+  {
+    IFS= read -r # 1..n
+    while IFS= read -r line; do
+      case "$line" in
+      "begin "* )
+        let index+=1
+        echo "${line/ $index / $(($offset + $index)) }"
+        ;;
+      "ok "* | "not ok "* )
+        [ -n "$extended_syntax_flag" ] || let index+=1
+        echo "${line/ $index / $(($offset + $index)) }"
+        [ "${line:0:6}" != "not ok" ] || status=1
+        ;;
+      * )
+        echo "$line"
+        ;;
+      esac
+    done
+  } < <( bats-exec-test $extended_syntax_flag "$filename" )
+  offset=$(($offset + $index))
+done
+
+exit "$status"

--- a/shell/test/bats-core/libexec/bats-exec-test
+++ b/shell/test/bats-core/libexec/bats-exec-test
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+set -e
+set -E
+set -T
+
+BATS_COUNT_ONLY=""
+if [ "$1" = "-c" ]; then
+  BATS_COUNT_ONLY=1
+  shift
+fi
+
+BATS_EXTENDED_SYNTAX=""
+if [ "$1" = "-x" ]; then
+  BATS_EXTENDED_SYNTAX="$1"
+  shift
+fi
+
+BATS_TEST_FILENAME="$1"
+if [ -z "$BATS_TEST_FILENAME" ]; then
+  echo "usage: bats-exec <filename>" >&2
+  exit 1
+elif [ ! -f "$BATS_TEST_FILENAME" ]; then
+  echo "bats: $BATS_TEST_FILENAME does not exist" >&2
+  exit 1
+else
+  shift
+fi
+
+BATS_TEST_DIRNAME="${BATS_TEST_FILENAME%/*}"
+BATS_TEST_NAMES=()
+
+load() {
+  local name="$1"
+  local filename
+
+  if [ "${name:0:1}" = "/" ]; then
+    filename="${name}"
+  else
+    filename="$BATS_TEST_DIRNAME/${name}.bash"
+  fi
+
+  if [[ ! -f "$filename" ]]; then
+    echo "bats: $filename does not exist" >&2
+    exit 1
+  fi
+
+  source "${filename}"
+}
+
+run() {
+  local e E T oldIFS
+  [[ ! "$-" =~ e ]] || e=1
+  [[ ! "$-" =~ E ]] || E=1
+  [[ ! "$-" =~ T ]] || T=1
+  set +e
+  set +E
+  set +T
+  output="$("$@" 2>&1)"
+  status="$?"
+  oldIFS=$IFS
+  IFS=$'\n' lines=($output)
+  [ -z "$e" ] || set -e
+  [ -z "$E" ] || set -E
+  [ -z "$T" ] || set -T
+  IFS=$oldIFS
+}
+
+setup() {
+  true
+}
+
+teardown() {
+  true
+}
+
+BATS_TEST_SKIPPED=''
+skip() {
+  BATS_TEST_SKIPPED=${1:-1}
+  BATS_TEST_COMPLETED=1
+  exit 0
+}
+
+bats_test_begin() {
+  BATS_TEST_DESCRIPTION="$1"
+  if [ -n "$BATS_EXTENDED_SYNTAX" ]; then
+    echo "begin $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION" >&3
+  fi
+  setup
+}
+
+bats_test_function() {
+  local test_name="$1"
+  BATS_TEST_NAMES+=("$test_name")
+}
+
+BATS_CURRENT_STACK_TRACE=()
+BATS_PREVIOUS_STACK_TRACE=()
+
+bats_capture_stack_trace() {
+  if [[ "${#BATS_CURRENT_STACK_TRACE[@]}" -ne '0' ]]; then
+    BATS_PREVIOUS_STACK_TRACE=("${BATS_CURRENT_STACK_TRACE[@]}")
+  fi
+  BATS_CURRENT_STACK_TRACE=()
+
+  local test_pattern=" $BATS_TEST_NAME $BATS_TEST_SOURCE"
+  local setup_pattern=" setup $BATS_TEST_SOURCE"
+  local teardown_pattern=" teardown $BATS_TEST_SOURCE"
+
+  local frame
+  local i
+
+  for ((i=2; i != ${#FUNCNAME[@]}; ++i)); do
+    frame="${BASH_LINENO[$((i-1))]} ${FUNCNAME[$i]} ${BASH_SOURCE[$i]}"
+    BATS_CURRENT_STACK_TRACE["${#BATS_CURRENT_STACK_TRACE[@]}"]="$frame"
+    if [[ "$frame" = *"$test_pattern"     || \
+          "$frame" = *"$setup_pattern"    || \
+          "$frame" = *"$teardown_pattern" ]]; then
+      break
+    fi
+  done
+
+  bats_frame_filename "${BATS_CURRENT_STACK_TRACE[0]}" 'BATS_SOURCE'
+  bats_frame_lineno "${BATS_CURRENT_STACK_TRACE[0]}" 'BATS_LINENO'
+}
+
+bats_print_stack_trace() {
+  local frame
+  local index=1
+  local count="${#@}"
+  local filename
+  local lineno
+
+  for frame in "$@"; do
+    bats_frame_filename "$frame" 'filename'
+    bats_trim_filename "$filename" 'filename'
+    bats_frame_lineno "$frame" 'lineno'
+
+    if [ $index -eq 1 ]; then
+      echo -n "# ("
+    else
+      echo -n "#  "
+    fi
+
+    local fn
+    bats_frame_function "$frame" 'fn'
+    if [ "$fn" != "$BATS_TEST_NAME" ]; then
+      echo -n "from function \`$fn' "
+    fi
+
+    if [ $index -eq $count ]; then
+      echo "in test file $filename, line $lineno)"
+    else
+      echo "in file $filename, line $lineno,"
+    fi
+
+    let index+=1
+  done
+}
+
+bats_print_failed_command() {
+  local frame="$1"
+  local status="$2"
+  local filename
+  local lineno
+  local failed_line
+  local failed_command
+
+  bats_frame_filename "$frame" 'filename'
+  bats_frame_lineno "$frame" 'lineno'
+  bats_extract_line "$filename" "$lineno" 'failed_line'
+  bats_strip_string "$failed_line" 'failed_command'
+  printf '%s' "#   \`${failed_command}' "
+
+  if [ $status -eq 1 ]; then
+    echo "failed"
+  else
+    echo "failed with status $status"
+  fi
+}
+
+bats_frame_lineno() {
+  printf -v "$2" '%s' "${1%% *}"
+}
+
+bats_frame_function() {
+  local __bff_function="${1#* }"
+  printf -v "$2" '%s' "${__bff_function%% *}"
+}
+
+bats_frame_filename() {
+  local __bff_filename="${1#* }"
+  __bff_filename="${__bff_filename#* }"
+
+  if [ "$__bff_filename" = "$BATS_TEST_SOURCE" ]; then
+    __bff_filename="$BATS_TEST_FILENAME"
+  fi
+  printf -v "$2" '%s' "$__bff_filename"
+}
+
+bats_extract_line() {
+  local __bats_extract_line_line
+  local __bats_extract_line_index='0'
+
+  while IFS= read -r __bats_extract_line_line; do
+    if [[ "$((++__bats_extract_line_index))" -eq "$2" ]]; then
+      printf -v "$3" '%s' "${__bats_extract_line_line%$'\r'}"
+      break
+    fi
+  done <"$1"
+}
+
+bats_strip_string() {
+  [[ "$1" =~ ^[[:space:]]*(.*)[[:space:]]*$ ]]
+  printf -v "$2" '%s' "${BASH_REMATCH[1]}"
+}
+
+bats_trim_filename() {
+  if [[ "$1" =~ ^${BATS_CWD}/ ]]; then
+    printf -v "$2" '%s' "${1#$BATS_CWD/}"
+  else
+    printf -v "$2" '%s' "$1"
+  fi
+}
+
+bats_debug_trap() {
+  if [ "$BASH_SOURCE" != "$1" ]; then
+    bats_capture_stack_trace
+  fi
+}
+
+# When running under Bash 3.2.57(1)-release on macOS, the `ERR` trap may not
+# always fire, but the `EXIT` trap will. For this reason we call it at the very
+# beginning of `bats_teardown_trap` (the `DEBUG` trap for the call will move
+# `BATS_CURRENT_STACK_TRACE` to `BATS_PREVIOUS_STACK_TRACE`) and check the value
+# of `$?` before taking other actions.
+bats_error_trap() {
+  local status="$?"
+  if [[ "$status" -ne '0' ]]; then
+    BATS_ERROR_STATUS="$status"
+    BATS_ERROR_STACK_TRACE=( "${BATS_PREVIOUS_STACK_TRACE[@]}" )
+    trap - debug
+  fi
+}
+
+bats_teardown_trap() {
+  bats_error_trap
+  trap "bats_exit_trap" exit
+  local status=0
+  teardown >>"$BATS_OUT" 2>&1 || status="$?"
+
+  if [ $status -eq 0 ]; then
+    BATS_TEARDOWN_COMPLETED=1
+  elif [ -n "$BATS_TEST_COMPLETED" ]; then
+    BATS_ERROR_STATUS="$status"
+    BATS_ERROR_STACK_TRACE=( "${BATS_CURRENT_STACK_TRACE[@]}" )
+  fi
+
+  bats_exit_trap
+}
+
+bats_exit_trap() {
+  local status
+  local skipped=''
+  trap - err exit
+
+  if [ -n "$BATS_TEST_SKIPPED" ]; then
+    skipped=" # skip"
+    if [ "1" != "$BATS_TEST_SKIPPED" ]; then
+      skipped+=" $BATS_TEST_SKIPPED"
+    fi
+  fi
+
+  if [ -z "$BATS_TEST_COMPLETED" ] || [ -z "$BATS_TEARDOWN_COMPLETED" ]; then
+    echo "not ok $BATS_TEST_NUMBER $BATS_TEST_DESCRIPTION" >&3
+    bats_print_stack_trace "${BATS_ERROR_STACK_TRACE[@]}" >&3
+    bats_print_failed_command "${BATS_ERROR_STACK_TRACE[${#BATS_ERROR_STACK_TRACE[@]}-1]}" "$BATS_ERROR_STATUS" >&3
+    sed -e "s/^/# /" < "$BATS_OUT" >&3
+    status=1
+  else
+    echo "ok ${BATS_TEST_NUMBER} ${BATS_TEST_DESCRIPTION}${skipped}" >&3
+    status=0
+  fi
+
+  rm -f "$BATS_OUT"
+  exit "$status"
+}
+
+bats_perform_tests() {
+  echo "1..$#"
+  test_number=1
+  status=0
+  for test_name in "$@"; do
+    "$0" $BATS_EXTENDED_SYNTAX "$BATS_TEST_FILENAME" "$test_name" "$test_number" || status=1
+    let test_number+=1
+  done
+  exit "$status"
+}
+
+bats_perform_test() {
+  BATS_TEST_NAME="$1"
+  if declare -F "$BATS_TEST_NAME" >/dev/null; then
+    BATS_TEST_NUMBER="$2"
+    if [ -z "$BATS_TEST_NUMBER" ]; then
+      echo "1..1"
+      BATS_TEST_NUMBER="1"
+    fi
+
+    BATS_TEST_COMPLETED=""
+    BATS_TEARDOWN_COMPLETED=""
+    trap "bats_debug_trap \"\$BASH_SOURCE\"" debug
+    trap "bats_error_trap" err
+    trap "bats_teardown_trap" exit
+    "$BATS_TEST_NAME" >>"$BATS_OUT" 2>&1
+    BATS_TEST_COMPLETED=1
+
+  else
+    echo "bats: unknown test name \`$BATS_TEST_NAME'" >&2
+    exit 1
+  fi
+}
+
+if [ -z "$TMPDIR" ]; then
+  BATS_TMPDIR="/tmp"
+else
+  BATS_TMPDIR="${TMPDIR%/}"
+fi
+
+BATS_TMPNAME="$BATS_TMPDIR/bats.$$"
+BATS_PARENT_TMPNAME="$BATS_TMPDIR/bats.$PPID"
+BATS_OUT="${BATS_TMPNAME}.out"
+
+bats_preprocess_source() {
+  BATS_TEST_SOURCE="${BATS_TMPNAME}.src"
+  . bats-preprocess <<< "$(< "$BATS_TEST_FILENAME")"$'\n' > "$BATS_TEST_SOURCE"
+  trap "bats_cleanup_preprocessed_source" err exit
+  trap "bats_cleanup_preprocessed_source; exit 1" int
+}
+
+bats_cleanup_preprocessed_source() {
+  rm -f "$BATS_TEST_SOURCE"
+}
+
+bats_evaluate_preprocessed_source() {
+  if [ -z "$BATS_TEST_SOURCE" ]; then
+    BATS_TEST_SOURCE="${BATS_PARENT_TMPNAME}.src"
+  fi
+  source "$BATS_TEST_SOURCE"
+}
+
+exec 3<&1
+
+if [ "$#" -eq 0 ]; then
+  bats_preprocess_source
+  bats_evaluate_preprocessed_source
+
+  if [ -n "$BATS_COUNT_ONLY" ]; then
+    echo "${#BATS_TEST_NAMES[@]}"
+  else
+    bats_perform_tests "${BATS_TEST_NAMES[@]}"
+  fi
+else
+  bats_evaluate_preprocessed_source
+  bats_perform_test "$@"
+fi

--- a/shell/test/bats-core/libexec/bats-format-tap-stream
+++ b/shell/test/bats-core/libexec/bats-format-tap-stream
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -e
+
+# Just stream the TAP output (sans extended syntax) if tput is missing
+command -v tput >/dev/null || exec grep -v "^begin "
+
+header_pattern='[0-9]+\.\.[0-9]+'
+IFS= read -r header
+
+if [[ "$header" =~ $header_pattern ]]; then
+  count="${header:3}"
+  index=0
+  failures=0
+  skipped=0
+  name=""
+  count_column_width=$(( ${#count} * 2 + 2 ))
+else
+  # If the first line isn't a TAP plan, print it and pass the rest through
+  printf "%s\n" "$header"
+  exec cat
+fi
+
+update_screen_width() {
+  screen_width="$(tput cols)"
+  count_column_left=$(( $screen_width - $count_column_width ))
+}
+
+trap update_screen_width WINCH
+update_screen_width
+
+begin() {
+  go_to_column 0
+  printf_with_truncation $(( $count_column_left - 1 )) "   %s" "$name"
+  clear_to_end_of_line
+  go_to_column $count_column_left
+  printf "%${#count}s/${count}" "$index"
+  go_to_column 1
+}
+
+pass() {
+  go_to_column 0
+  printf " ✓ %s" "$name"
+  advance
+}
+
+skip() {
+  local reason="$1"
+  [ -z "$reason" ] || reason=": $reason"
+  go_to_column 0
+  printf " - %s (skipped%s)" "$name" "$reason"
+  advance
+}
+
+fail() {
+  go_to_column 0
+  set_color 1 bold
+  printf " ✗ %s" "$name"
+  advance
+}
+
+log() {
+  set_color 1
+  printf "   %s\n" "$1"
+  clear_color
+}
+
+summary() {
+  printf "\n%d test" "$count"
+  if [[ "$count" -ne '1' ]]; then
+    printf 's'
+  fi
+
+  printf ", %d failure" "$failures"
+  if [[ "$failures" -ne '1' ]]; then
+    printf 's'
+  fi
+
+  if [ "$skipped" -gt 0 ]; then
+    printf ", %d skipped" "$skipped"
+  fi
+
+  printf "\n"
+}
+
+printf_with_truncation() {
+  local width="$1"
+  shift
+  local string
+
+  printf -v 'string' -- "$@"
+
+  if [ "${#string}" -gt "$width" ]; then
+    printf "%s..." "${string:0:$(( $width - 4 ))}"
+  else
+    printf "%s" "$string"
+  fi
+}
+
+go_to_column() {
+  local column="$1"
+  printf "\x1B[%dG" $(( $column + 1 ))
+}
+
+clear_to_end_of_line() {
+  printf "\x1B[K"
+}
+
+advance() {
+  clear_to_end_of_line
+  echo
+  clear_color
+}
+
+set_color() {
+  local color="$1"
+  local weight='22'
+
+  if [[ "$2" == 'bold' ]]; then
+    weight='1'
+  fi
+  printf "\x1B[%d;%dm" $(( 30 + $color )) "$weight"
+}
+
+clear_color() {
+  printf "\x1B[0m"
+}
+
+_buffer=""
+
+buffer() {
+  _buffer="${_buffer}$("$@")"
+}
+
+flush() {
+  printf "%s" "$_buffer"
+  _buffer=""
+}
+
+finish() {
+  flush
+  printf "\n"
+}
+
+trap finish EXIT
+
+while IFS= read -r line; do
+  case "$line" in
+  "begin "* )
+    let index+=1
+    name="${line#* $index }"
+    buffer begin
+    flush
+    ;;
+  "ok "* )
+    skip_expr="ok $index (.*) # skip ?(([^)]*))?"
+    if [[ "$line" =~ $skip_expr ]]; then
+      let skipped+=1
+      buffer skip "${BASH_REMATCH[2]}"
+    else
+      buffer pass
+    fi
+    ;;
+  "not ok "* )
+    let failures+=1
+    buffer fail
+    ;;
+  "# "* )
+    buffer log "${line:2}"
+    ;;
+  esac
+done
+
+buffer summary

--- a/shell/test/bats-core/libexec/bats-preprocess
+++ b/shell/test/bats-core/libexec/bats-preprocess
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -e
+
+encode_name() {
+  local name="$1"
+  local result="test_"
+  local hex_code
+
+  if [[ ! "$name" =~ [^[:alnum:]\ _-] ]]; then
+    name="${name//_/-5f}"
+    name="${name//-/-2d}"
+    name="${name// /_}"
+    result+="$name"
+  else
+    local length="${#name}"
+    local char i
+
+    for ((i=0; i<length; i++)); do
+      char="${name:$i:1}"
+      if [ "$char" = " " ]; then
+        result+="_"
+      elif [[ "$char" =~ [[:alnum:]] ]]; then
+        result+="$char"
+      else
+        printf -v 'hex_code' -- "-%02x" \'"$char"
+        result+="$hex_code"
+      fi
+    done
+  fi
+
+  printf -v "$2" '%s' "$result"
+}
+
+tests=()
+index=0
+
+while IFS= read -r line; do
+  line="${line//$'\r'}"
+  let index+=1
+  if [[ "$line" =~ $BATS_TEST_PATTERN ]]; then
+    name="${BASH_REMATCH[1]#[\'\"]}"
+    name="${name%[\'\"]}"
+    body="${BASH_REMATCH[2]}"
+    encode_name "$name" 'encoded_name'
+    tests["${#tests[@]}"]="$encoded_name"
+    echo "${encoded_name}() { bats_test_begin \"${name}\" ${index}; ${body}"
+  else
+    printf "%s\n" "$line"
+  fi
+done
+
+for test_name in "${tests[@]}"; do
+  echo "bats_test_function ${test_name}"
+done

--- a/shell/test/bats-core/test/bats.bats
+++ b/shell/test/bats-core/test/bats.bats
@@ -1,0 +1,357 @@
+#!/usr/bin/env bats
+
+load test_helper
+fixtures bats
+
+@test "no arguments prints usage instructions" {
+  run bats
+  [ $status -eq 1 ]
+  [ $(expr "${lines[1]}" : "Usage:") -ne 0 ]
+}
+
+@test "-v and --version print version number" {
+  run bats -v
+  [ $status -eq 0 ]
+  [ $(expr "$output" : "Bats [0-9][0-9.]*") -ne 0 ]
+}
+
+@test "-h and --help print help" {
+  run bats -h
+  [ $status -eq 0 ]
+  [ "${#lines[@]}" -gt 3 ]
+}
+
+@test "invalid filename prints an error" {
+  run bats nonexistent
+  [ $status -eq 1 ]
+  [ $(expr "$output" : ".*does not exist") -ne 0 ]
+}
+
+@test "empty test file runs zero tests" {
+  run bats "$FIXTURE_ROOT/empty.bats"
+  [ $status -eq 0 ]
+  [ "$output" = "1..0" ]
+}
+
+@test "one passing test" {
+  run bats "$FIXTURE_ROOT/passing.bats"
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "1..1" ]
+  [ "${lines[1]}" = "ok 1 a passing test" ]
+}
+
+@test "summary passing tests" {
+  run filter_control_sequences bats -p "$FIXTURE_ROOT/passing.bats"
+  [ $status -eq 0 ]
+  [ "${lines[1]}" = "1 test, 0 failures" ]
+}
+
+@test "summary passing and skipping tests" {
+  run filter_control_sequences bats -p "$FIXTURE_ROOT/passing_and_skipping.bats"
+  [ $status -eq 0 ]
+  [ "${lines[3]}" = "3 tests, 0 failures, 2 skipped" ]
+}
+
+@test "tap passing and skipping tests" {
+  run filter_control_sequences bats --tap "$FIXTURE_ROOT/passing_and_skipping.bats"
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "1..3" ]
+  [ "${lines[1]}" = "ok 1 a passing test" ]
+  [ "${lines[2]}" = "ok 2 a skipped test with no reason # skip" ]
+  [ "${lines[3]}" = "ok 3 a skipped test with a reason # skip for a really good reason" ]
+}
+
+@test "summary passing and failing tests" {
+  run filter_control_sequences bats -p "$FIXTURE_ROOT/failing_and_passing.bats"
+  [ $status -eq 0 ]
+  [ "${lines[4]}" = "2 tests, 1 failure" ]
+}
+
+@test "summary passing, failing and skipping tests" {
+  run filter_control_sequences bats -p "$FIXTURE_ROOT/passing_failing_and_skipping.bats"
+  [ $status -eq 0 ]
+  [ "${lines[5]}" = "3 tests, 1 failure, 1 skipped" ]
+}
+
+@test "tap passing, failing and skipping tests" {
+  run filter_control_sequences bats --tap "$FIXTURE_ROOT/passing_failing_and_skipping.bats"
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "1..3" ]
+  [ "${lines[1]}" = "ok 1 a passing test" ]
+  [ "${lines[2]}" = "ok 2 a skipping test # skip" ]
+  [ "${lines[3]}" = "not ok 3 a failing test" ]
+}
+
+@test "one failing test" {
+  run bats "$FIXTURE_ROOT/failing.bats"
+  [ $status -eq 1 ]
+  emit_debug_output
+  [ "${lines[0]}" = '1..1' ]
+  [ "${lines[1]}" = 'not ok 1 a failing test' ]
+  [ "${lines[2]}" = "# (in test file $RELATIVE_FIXTURE_ROOT/failing.bats, line 4)" ]
+  [ "${lines[3]}" = "#   \`eval \"( exit \${STATUS:-1} )\"' failed" ]
+}
+
+@test "one failing and one passing test" {
+  run bats "$FIXTURE_ROOT/failing_and_passing.bats"
+  [ $status -eq 1 ]
+  [ "${lines[0]}" = '1..2' ]
+  [ "${lines[1]}" = 'not ok 1 a failing test' ]
+  [ "${lines[2]}" = "# (in test file $RELATIVE_FIXTURE_ROOT/failing_and_passing.bats, line 2)" ]
+  [ "${lines[3]}" = "#   \`false' failed" ]
+  [ "${lines[4]}" = 'ok 2 a passing test' ]
+}
+
+@test "failing test with significant status" {
+  STATUS=2 run bats "$FIXTURE_ROOT/failing.bats"
+  [ $status -eq 1 ]
+  emit_debug_output
+  [ "${lines[3]}" = "#   \`eval \"( exit \${STATUS:-1} )\"' failed with status 2" ]
+}
+
+@test "failing helper function logs the test case's line number" {
+  run bats "$FIXTURE_ROOT/failing_helper.bats"
+  [ $status -eq 1 ]
+  [ "${lines[1]}" = 'not ok 1 failing helper function' ]
+  [ "${lines[2]}" = "# (from function \`failing_helper' in file $RELATIVE_FIXTURE_ROOT/test_helper.bash, line 6," ]
+  [ "${lines[3]}" = "#  in test file $RELATIVE_FIXTURE_ROOT/failing_helper.bats, line 5)" ]
+  [ "${lines[4]}" = "#   \`failing_helper' failed" ]
+}
+
+@test "test environments are isolated" {
+  run bats "$FIXTURE_ROOT/environment.bats"
+  [ $status -eq 0 ]
+}
+
+@test "setup is run once before each test" {
+  rm -f "$TMP/setup.log"
+  run bats "$FIXTURE_ROOT/setup.bats"
+  [ $status -eq 0 ]
+  run cat "$TMP/setup.log"
+  [ ${#lines[@]} -eq 3 ]
+}
+
+@test "teardown is run once after each test, even if it fails" {
+  rm -f "$TMP/teardown.log"
+  run bats "$FIXTURE_ROOT/teardown.bats"
+  [ $status -eq 1 ]
+  run cat "$TMP/teardown.log"
+  [ ${#lines[@]} -eq 3 ]
+}
+
+@test "setup failure" {
+  run bats "$FIXTURE_ROOT/failing_setup.bats"
+  [ $status -eq 1 ]
+  [ "${lines[1]}" = 'not ok 1 truth' ]
+  [ "${lines[2]}" = "# (from function \`setup' in test file $RELATIVE_FIXTURE_ROOT/failing_setup.bats, line 2)" ]
+  [ "${lines[3]}" = "#   \`false' failed" ]
+}
+
+@test "passing test with teardown failure" {
+  PASS=1 run bats "$FIXTURE_ROOT/failing_teardown.bats"
+  [ $status -eq 1 ]
+  [ "${lines[1]}" = 'not ok 1 truth' ]
+  [ "${lines[2]}" = "# (from function \`teardown' in test file $RELATIVE_FIXTURE_ROOT/failing_teardown.bats, line 2)" ]
+  [ "${lines[3]}" = "#   \`eval \"( exit \${STATUS:-1} )\"' failed" ]
+}
+
+@test "failing test with teardown failure" {
+  PASS=0 run bats "$FIXTURE_ROOT/failing_teardown.bats"
+  [ $status -eq 1 ]
+  [ "${lines[1]}" =  'not ok 1 truth' ]
+  [ "${lines[2]}" =  "# (in test file $RELATIVE_FIXTURE_ROOT/failing_teardown.bats, line 6)" ]
+  [ "${lines[3]}" = $'#   `[ "$PASS" = "1" ]\' failed' ]
+}
+
+@test "teardown failure with significant status" {
+  PASS=1 STATUS=2 run bats "$FIXTURE_ROOT/failing_teardown.bats"
+  [ $status -eq 1 ]
+  [ "${lines[3]}" = "#   \`eval \"( exit \${STATUS:-1} )\"' failed with status 2" ]
+}
+
+@test "failing test file outside of BATS_CWD" {
+  cd "$TMP"
+  run bats "$FIXTURE_ROOT/failing.bats"
+  [ $status -eq 1 ]
+  emit_debug_output
+  [ "${lines[2]}" = "# (in test file $FIXTURE_ROOT/failing.bats, line 4)" ]
+}
+
+@test "load sources scripts relative to the current test file" {
+  run bats "$FIXTURE_ROOT/load.bats"
+  [ $status -eq 0 ]
+}
+
+@test "load aborts if the specified script does not exist" {
+  HELPER_NAME="nonexistent" run bats "$FIXTURE_ROOT/load.bats"
+  [ $status -eq 1 ]
+}
+
+@test "load sources scripts by absolute path" {
+  HELPER_NAME="${FIXTURE_ROOT}/test_helper.bash" run bats "$FIXTURE_ROOT/load.bats"
+  [ $status -eq 0 ]
+}
+
+@test "load aborts if the script, specified by an absolute path, does not exist" {
+  HELPER_NAME="${FIXTURE_ROOT}/nonexistent" run bats "$FIXTURE_ROOT/load.bats"
+  [ $status -eq 1 ]
+}
+
+@test "output is discarded for passing tests and printed for failing tests" {
+  run bats "$FIXTURE_ROOT/output.bats"
+  [ $status -eq 1 ]
+  [ "${lines[6]}"  = '# failure stdout 1' ]
+  [ "${lines[7]}"  = '# failure stdout 2' ]
+  [ "${lines[11]}" = '# failure stderr' ]
+}
+
+@test "-c prints the number of tests" {
+  run bats -c "$FIXTURE_ROOT/empty.bats"
+  [ $status -eq 0 ]
+  [ "$output" = "0" ]
+
+  run bats -c "$FIXTURE_ROOT/output.bats"
+  [ $status -eq 0 ]
+  [ "$output" = "4" ]
+}
+
+@test "dash-e is not mangled on beginning of line" {
+  run bats "$FIXTURE_ROOT/intact.bats"
+  [ $status -eq 0 ]
+  [ "${lines[1]}" = "ok 1 dash-e on beginning of line" ]
+}
+
+@test "dos line endings are stripped before testing" {
+  run bats "$FIXTURE_ROOT/dos_line.bats"
+  [ $status -eq 0 ]
+}
+
+@test "test file without trailing newline" {
+  run bats "$FIXTURE_ROOT/without_trailing_newline.bats"
+  [ $status -eq 0 ]
+  [ "${lines[1]}" = "ok 1 truth" ]
+}
+
+@test "skipped tests" {
+  run bats "$FIXTURE_ROOT/skipped.bats"
+  [ $status -eq 0 ]
+  [ "${lines[1]}" = "ok 1 a skipped test # skip" ]
+  [ "${lines[2]}" = "ok 2 a skipped test with a reason # skip a reason" ]
+}
+
+@test "extended syntax" {
+  run bats-exec-test -x "$FIXTURE_ROOT/failing_and_passing.bats"
+  [ $status -eq 1 ]
+  [ "${lines[1]}" = 'begin 1 a failing test' ]
+  [ "${lines[2]}" = 'not ok 1 a failing test' ]
+  [ "${lines[5]}" = 'begin 2 a passing test' ]
+  [ "${lines[6]}" = 'ok 2 a passing test' ]
+}
+
+@test "pretty and tap formats" {
+  run bats --tap "$FIXTURE_ROOT/passing.bats"
+  tap_output="$output"
+  [ $status -eq 0 ]
+
+  run bats --pretty "$FIXTURE_ROOT/passing.bats"
+  pretty_output="$output"
+  [ $status -eq 0 ]
+
+  [ "$tap_output" != "$pretty_output" ]
+}
+
+@test "pretty formatter bails on invalid tap" {
+  run bats --tap "$FIXTURE_ROOT/invalid_tap.bats"
+  [ $status -eq 1 ]
+  [ "${lines[0]}" = "This isn't TAP!" ]
+  [ "${lines[1]}" = "Good day to you" ]
+}
+
+@test "single-line tests" {
+  run bats "$FIXTURE_ROOT/single_line.bats"
+  [ $status -eq 1 ]
+  [ "${lines[1]}" =  'ok 1 empty' ]
+  [ "${lines[2]}" =  'ok 2 passing' ]
+  [ "${lines[3]}" =  'ok 3 input redirection' ]
+  [ "${lines[4]}" =  'not ok 4 failing' ]
+  [ "${lines[5]}" =  "# (in test file $RELATIVE_FIXTURE_ROOT/single_line.bats, line 9)" ]
+  [ "${lines[6]}" = $'#   `@test "failing" { false; }\' failed' ]
+}
+
+@test "testing IFS not modified by run" {
+  run bats "$FIXTURE_ROOT/loop_keep_IFS.bats"
+  [ $status -eq 0 ]
+  [ "${lines[1]}" = "ok 1 loop_func" ]
+}
+
+@test "expand variables in test name" {
+  SUITE='test/suite' run bats "$FIXTURE_ROOT/expand_var_in_test_name.bats"
+  [ $status -eq 0 ]
+  [ "${lines[1]}" = "ok 1 test/suite: test with variable in name" ]
+}
+
+@test "handle quoted and unquoted test names" {
+  run bats "$FIXTURE_ROOT/quoted_and_unquoted_test_names.bats"
+  [ $status -eq 0 ]
+  [ "${lines[1]}" = "ok 1 single-quoted name" ]
+  [ "${lines[2]}" = "ok 2 double-quoted name" ]
+  [ "${lines[3]}" = "ok 3 unquoted name" ]
+}
+
+@test 'ensure compatibility with unofficial Bash strict mode' {
+  local expected='ok 1 unofficial Bash strict mode conditions met'
+
+  # Run Bats under `set -u` to catch as many unset variable accesses as
+  # possible.
+  run bash -u "${BATS_TEST_DIRNAME%/*}/libexec/bats" \
+    "$FIXTURE_ROOT/unofficial_bash_strict_mode.bats"
+  if [[ "$status" -ne '0' || "${lines[1]}" != "$expected" ]]; then
+    cat <<END_OF_ERR_MSG
+
+This test failed because the Bats internals are violating one of the
+constraints imposed by:
+
+--------
+$(< "$FIXTURE_ROOT/unofficial_bash_strict_mode.bash")
+--------
+
+See:
+- https://github.com/sstephenson/bats/issues/171
+- http://redsymbol.net/articles/unofficial-bash-strict-mode/
+
+If there is no error output from the test fixture, run the following to
+debug the problem:
+
+  $ bash -u bats $RELATIVE_FIXTURE_ROOT/unofficial_bash_strict_mode.bats
+
+If there's no error output even with this command, make sure you're using the
+latest version of Bash, as versions before 4.1-alpha may not produce any error
+output for unset variable accesses.
+
+If there's no output even when running the latest Bash, the problem may reside
+in the DEBUG trap handler. A particularly sneaky issue is that in Bash before
+4.1-alpha, an expansion of an empty array, e.g. "\${FOO[@]}", is considered
+an unset variable access. The solution is to add a size check before the
+expansion, e.g. [[ "\${#FOO[@]}" -ne '0' ]].
+
+END_OF_ERR_MSG
+    emit_debug_output && return 1
+  fi
+}
+
+@test "parse @test lines with various whitespace combinations" {
+  run bats "$FIXTURE_ROOT/whitespace.bats"
+  emit_debug_output
+  [ $status -eq 0 ]
+  [ "${lines[1]}" = 'ok 1 no extra whitespace' ]
+  [ "${lines[2]}" = 'ok 2 tab at beginning of line' ]
+  [ "${lines[3]}" = 'ok 3 tab before description' ]
+  [ "${lines[4]}" = 'ok 4 tab before opening brace' ]
+  [ "${lines[5]}" = 'ok 5 tabs at beginning of line and before description' ]
+  [ "${lines[6]}" = 'ok 6 tabs at beginning, before description, before brace' ]
+  [ "${lines[7]}" = 'ok 7 extra whitespace around single-line test' ]
+  [ "${lines[8]}" = 'ok 8 no extra whitespace around single-line test' ]
+  [ "${lines[9]}" = 'ok 9 parse unquoted name between extra whitespace' ]
+  [ "${lines[10]}" = 'ok 10 {' ]  # unquoted single brace is a valid description
+  [ "${lines[11]}" = 'ok 11 ' ]   # empty name from single quote
+}

--- a/shell/test/bats-core/test/fixtures/bats/dos_line.bats
+++ b/shell/test/bats-core/test/fixtures/bats/dos_line.bats
@@ -1,0 +1,3 @@
+@test "foo" {
+  echo "foo"
+}

--- a/shell/test/bats-core/test/fixtures/bats/environment.bats
+++ b/shell/test/bats-core/test/fixtures/bats/environment.bats
@@ -1,0 +1,8 @@
+@test "setting a variable" {
+  variable=1
+  [ $variable -eq 1 ]
+}
+
+@test "variables do not persist across tests" {
+  [ -z "$variable" ]
+}

--- a/shell/test/bats-core/test/fixtures/bats/expand_var_in_test_name.bats
+++ b/shell/test/bats-core/test/fixtures/bats/expand_var_in_test_name.bats
@@ -1,0 +1,3 @@
+@test "$SUITE: test with variable in name" {
+  true
+}

--- a/shell/test/bats-core/test/fixtures/bats/failing.bats
+++ b/shell/test/bats-core/test/fixtures/bats/failing.bats
@@ -1,0 +1,5 @@
+@test "a failing test" {
+  true
+  true
+  eval "( exit ${STATUS:-1} )"
+}

--- a/shell/test/bats-core/test/fixtures/bats/failing_and_passing.bats
+++ b/shell/test/bats-core/test/fixtures/bats/failing_and_passing.bats
@@ -1,0 +1,7 @@
+@test "a failing test" {
+  false
+}
+
+@test "a passing test" {
+  true
+}

--- a/shell/test/bats-core/test/fixtures/bats/failing_helper.bats
+++ b/shell/test/bats-core/test/fixtures/bats/failing_helper.bats
@@ -1,0 +1,6 @@
+load "test_helper"
+
+@test "failing helper function" {
+  true
+  failing_helper
+}

--- a/shell/test/bats-core/test/fixtures/bats/failing_setup.bats
+++ b/shell/test/bats-core/test/fixtures/bats/failing_setup.bats
@@ -1,0 +1,7 @@
+setup() {
+  false
+}
+
+@test "truth" {
+  true
+}

--- a/shell/test/bats-core/test/fixtures/bats/failing_teardown.bats
+++ b/shell/test/bats-core/test/fixtures/bats/failing_teardown.bats
@@ -1,0 +1,7 @@
+teardown() {
+  eval "( exit ${STATUS:-1} )"
+}
+
+@test "truth" {
+  [ "$PASS" = "1" ]
+}

--- a/shell/test/bats-core/test/fixtures/bats/intact.bats
+++ b/shell/test/bats-core/test/fixtures/bats/intact.bats
@@ -1,0 +1,6 @@
+@test "dash-e on beginning of line" {
+  run cat - <<INPUT
+-e
+INPUT
+  test "$output" = "-e"
+}

--- a/shell/test/bats-core/test/fixtures/bats/invalid_tap.bats
+++ b/shell/test/bats-core/test/fixtures/bats/invalid_tap.bats
@@ -1,0 +1,7 @@
+echo "This isn't TAP!"
+echo "Good day to you"
+exit 1
+
+@test "truth" {
+  true
+}

--- a/shell/test/bats-core/test/fixtures/bats/load.bats
+++ b/shell/test/bats-core/test/fixtures/bats/load.bats
@@ -1,0 +1,6 @@
+[ -n "$HELPER_NAME" ] || HELPER_NAME="test_helper"
+load "$HELPER_NAME"
+
+@test "calling a loaded helper" {
+  help_me
+}

--- a/shell/test/bats-core/test/fixtures/bats/loop_keep_IFS.bats
+++ b/shell/test/bats-core/test/fixtures/bats/loop_keep_IFS.bats
@@ -1,0 +1,16 @@
+# see issue #89
+loop_func() {
+  local search="none one two tree"
+  local d
+
+  for d in $search ; do
+    echo $d
+  done
+}
+
+@test "loop_func" {
+  run loop_func
+  [[ "${lines[3]}" == 'tree' ]]
+  run loop_func
+  [[ "${lines[2]}" == 'two' ]]
+}

--- a/shell/test/bats-core/test/fixtures/bats/output.bats
+++ b/shell/test/bats-core/test/fixtures/bats/output.bats
@@ -1,0 +1,19 @@
+@test "success writing to stdout" {
+  echo "success stdout 1"
+  echo "success stdout 2"
+}
+
+@test "success writing to stderr" {
+  echo "success stderr" >&2
+}
+
+@test "failure writing to stdout" {
+  echo "failure stdout 1"
+  echo "failure stdout 2"
+  false
+}
+
+@test "failure writing to stderr" {
+  echo "failure stderr" >&2
+  false
+}

--- a/shell/test/bats-core/test/fixtures/bats/passing.bats
+++ b/shell/test/bats-core/test/fixtures/bats/passing.bats
@@ -1,0 +1,3 @@
+@test "a passing test" {
+  true
+}

--- a/shell/test/bats-core/test/fixtures/bats/passing_and_failing.bats
+++ b/shell/test/bats-core/test/fixtures/bats/passing_and_failing.bats
@@ -1,0 +1,7 @@
+@test "a passing test" {
+  true
+}
+
+@test "a failing test" {
+  false
+}

--- a/shell/test/bats-core/test/fixtures/bats/passing_and_skipping.bats
+++ b/shell/test/bats-core/test/fixtures/bats/passing_and_skipping.bats
@@ -1,0 +1,11 @@
+@test "a passing test" {
+  true
+}
+
+@test "a skipped test with no reason" {
+  skip
+}
+
+@test "a skipped test with a reason" {
+  skip "for a really good reason"
+}

--- a/shell/test/bats-core/test/fixtures/bats/passing_failing_and_skipping.bats
+++ b/shell/test/bats-core/test/fixtures/bats/passing_failing_and_skipping.bats
@@ -1,0 +1,11 @@
+@test "a passing test" {
+  true
+}
+
+@test "a skipping test" {
+  skip
+}
+
+@test "a failing test" {
+  false
+}

--- a/shell/test/bats-core/test/fixtures/bats/quoted_and_unquoted_test_names.bats
+++ b/shell/test/bats-core/test/fixtures/bats/quoted_and_unquoted_test_names.bats
@@ -1,0 +1,11 @@
+@test 'single-quoted name' {
+  true
+}
+
+@test "double-quoted name" {
+  true
+}
+
+@test unquoted name {
+  true
+}

--- a/shell/test/bats-core/test/fixtures/bats/setup.bats
+++ b/shell/test/bats-core/test/fixtures/bats/setup.bats
@@ -1,0 +1,17 @@
+LOG="$TMP/setup.log"
+
+setup() {
+  echo "$BATS_TEST_NAME" >> "$LOG"
+}
+
+@test "one" {
+  [ "$(tail -n 1 "$LOG")" = "test_one" ]
+}
+
+@test "two" {
+  [ "$(tail -n 1 "$LOG")" = "test_two" ]
+}
+
+@test "three" {
+  [ "$(tail -n 1 "$LOG")" = "test_three" ]
+}

--- a/shell/test/bats-core/test/fixtures/bats/single_line.bats
+++ b/shell/test/bats-core/test/fixtures/bats/single_line.bats
@@ -1,0 +1,9 @@
+@test "empty" { }
+
+@test "passing" { true; }
+
+@test "input redirection" { diff - <( echo hello ); } <<EOS
+hello
+EOS
+
+@test "failing" { false; }

--- a/shell/test/bats-core/test/fixtures/bats/skipped.bats
+++ b/shell/test/bats-core/test/fixtures/bats/skipped.bats
@@ -1,0 +1,7 @@
+@test "a skipped test" {
+  skip
+}
+
+@test "a skipped test with a reason" {
+  skip "a reason"
+}

--- a/shell/test/bats-core/test/fixtures/bats/teardown.bats
+++ b/shell/test/bats-core/test/fixtures/bats/teardown.bats
@@ -1,0 +1,17 @@
+LOG="$TMP/teardown.log"
+
+teardown() {
+  echo "$BATS_TEST_NAME" >> "$LOG"
+}
+
+@test "one" {
+  true
+}
+
+@test "two" {
+  false
+}
+
+@test "three" {
+  true
+}

--- a/shell/test/bats-core/test/fixtures/bats/test_helper.bash
+++ b/shell/test/bats-core/test/fixtures/bats/test_helper.bash
@@ -1,0 +1,7 @@
+help_me() {
+  true
+}
+
+failing_helper() {
+  false
+}

--- a/shell/test/bats-core/test/fixtures/bats/unofficial_bash_strict_mode.bash
+++ b/shell/test/bats-core/test/fixtures/bats/unofficial_bash_strict_mode.bash
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+set -euo pipefail
+IFS=$'\n\t'

--- a/shell/test/bats-core/test/fixtures/bats/unofficial_bash_strict_mode.bats
+++ b/shell/test/bats-core/test/fixtures/bats/unofficial_bash_strict_mode.bats
@@ -1,0 +1,4 @@
+load unofficial_bash_strict_mode
+@test "unofficial Bash strict mode conditions met" {
+  :
+}

--- a/shell/test/bats-core/test/fixtures/bats/whitespace.bats
+++ b/shell/test/bats-core/test/fixtures/bats/whitespace.bats
@@ -1,0 +1,33 @@
+@test "no extra whitespace" {
+  :
+}
+
+	@test "tab at beginning of line" {
+	  :
+	}
+
+@test	"tab before description" {
+  :
+}
+
+@test "tab before opening brace"	{
+  :
+}
+
+	@test	"tabs at beginning of line and before description" {
+	  :
+	}
+
+	@test	"tabs at beginning, before description, before brace"	{
+	  :
+	}
+
+	 @test	 "extra whitespace around single-line test"	 {	 :;	 }	 
+
+@test "no extra whitespace around single-line test" {:;}
+
+@test	 parse unquoted name between extra whitespace 	{:;}
+
+@test { {:;}  # unquote single brace is a valid description
+
+@test ' {:;}  # empty name from single quote

--- a/shell/test/bats-core/test/fixtures/bats/without_trailing_newline.bats
+++ b/shell/test/bats-core/test/fixtures/bats/without_trailing_newline.bats
@@ -1,0 +1,3 @@
+@test "truth" {
+  true
+}

--- a/shell/test/bats-core/test/fixtures/suite/multiple/a.bats
+++ b/shell/test/bats-core/test/fixtures/suite/multiple/a.bats
@@ -1,0 +1,3 @@
+@test "truth" {
+  true
+}

--- a/shell/test/bats-core/test/fixtures/suite/multiple/b.bats
+++ b/shell/test/bats-core/test/fixtures/suite/multiple/b.bats
@@ -1,0 +1,7 @@
+@test "more truth" {
+  true
+}
+
+@test "quasi-truth" {
+  [ -z "$FLUNK" ]
+}

--- a/shell/test/bats-core/test/fixtures/suite/single/test.bats
+++ b/shell/test/bats-core/test/fixtures/suite/single/test.bats
@@ -1,0 +1,3 @@
+@test "a passing test" {
+  true
+}

--- a/shell/test/bats-core/test/suite.bats
+++ b/shell/test/bats-core/test/suite.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+load test_helper
+fixtures suite
+
+@test "running a suite with no test files" {
+  run bats "$FIXTURE_ROOT/empty"
+  [ $status -eq 0 ]
+  [ "$output" = "1..0" ]
+}
+
+@test "running a suite with one test file" {
+  run bats "$FIXTURE_ROOT/single"
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "1..1" ]
+  [ "${lines[1]}" = "ok 1 a passing test" ]
+}
+
+@test "counting tests in a suite" {
+  run bats -c "$FIXTURE_ROOT/single"
+  [ $status -eq 0 ]
+  [ "$output" -eq 1 ]
+
+  run bats -c "$FIXTURE_ROOT/multiple"
+  [ $status -eq 0 ]
+  [ "$output" -eq 3 ]
+}
+
+@test "aggregated output of multiple tests in a suite" {
+  run bats "$FIXTURE_ROOT/multiple"
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "1..3" ]
+  echo "$output" | grep "^ok . truth"
+  echo "$output" | grep "^ok . more truth"
+  echo "$output" | grep "^ok . quasi-truth"
+}
+
+@test "a failing test in a suite results in an error exit code" {
+  FLUNK=1 run bats "$FIXTURE_ROOT/multiple"
+  [ $status -eq 1 ]
+  [ "${lines[0]}" = "1..3" ]
+  echo "$output" | grep "^not ok . quasi-truth"
+}
+
+@test "running an ad-hoc suite by specifying multiple test files" {
+  run bats "$FIXTURE_ROOT/multiple/a.bats" "$FIXTURE_ROOT/multiple/b.bats"
+  [ $status -eq 0 ]
+  [ "${lines[0]}" = "1..3" ]
+  echo "$output" | grep "^ok . truth"
+  echo "$output" | grep "^ok . more truth"
+  echo "$output" | grep "^ok . quasi-truth"
+}
+
+@test "extended syntax in suite" {
+  FLUNK=1 run bats-exec-suite -x "$FIXTURE_ROOT/multiple/"*.bats
+  [ $status -eq 1 ]
+  [ "${lines[0]}" = "1..3" ]
+  [ "${lines[1]}" = "begin 1 truth" ]
+  [ "${lines[2]}" = "ok 1 truth" ]
+  [ "${lines[3]}" = "begin 2 more truth" ]
+  [ "${lines[4]}" = "ok 2 more truth" ]
+  [ "${lines[5]}" = "begin 3 quasi-truth" ]
+  [ "${lines[6]}" = "not ok 3 quasi-truth" ]
+}

--- a/shell/test/bats-core/test/test_helper.bash
+++ b/shell/test/bats-core/test/test_helper.bash
@@ -1,0 +1,27 @@
+fixtures() {
+  FIXTURE_ROOT="$BATS_TEST_DIRNAME/fixtures/$1"
+  bats_trim_filename "$FIXTURE_ROOT" 'RELATIVE_FIXTURE_ROOT'
+}
+
+setup() {
+  export TMP="$BATS_TEST_DIRNAME/tmp"
+}
+
+filter_control_sequences() {
+  "$@" | sed $'s,\x1b\\[[0-9;]*[a-zA-Z],,g'
+}
+
+if ! command -v tput >/dev/null; then
+  tput() {
+    printf '1000\n'
+  }
+  export -f tput
+fi
+
+emit_debug_output() {
+  printf '%s\n' 'output:' "$output" >&2
+}
+
+teardown() {
+  [ -d "$TMP" ] && rm -f "$TMP"/*
+}


### PR DESCRIPTION
Binary files for "bats" were missing as git treats clones repositories as "submodules". This branch freezes the repo https://github.com/bats-core/bats-core and adds mandatory files into /shell/tests 